### PR TITLE
density_histogram_test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand_distr = "0.4"
 serde = {version = "1", features = ["derive"], optional = true}
 special = "0.10"
 num-traits = "0.2"
-rand_xoshiro = { version = "0.6", optional = true, features=["serde1"]}
+rand_xoshiro = { version = "0.6", features = ["serde1"] }
 itertools = "0.13"
 paste = "1.0.15"
 
@@ -48,7 +48,7 @@ serde1 = ["serde", "nalgebra/serde-serialize"]
 arraydist = ["nalgebra"]
 process = ["serde", "nalgebra/serde-serialize", "argmin", "argmin-math", "arraydist"]
 datum = []
-experimental = ["rand_xoshiro"]
+
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -398,14 +398,6 @@ mod tests {
     }
 
     #[test]
-    fn new_should_not_allow_mu_outside_0_2pi() {
-        assert!(VonMises::new(-PI, 1.0).is_err());
-        assert!(VonMises::new(-f64::EPSILON, 1.0).is_err());
-        assert!(VonMises::new(2.0_f64.mul_add(PI, 0.001), 1.0).is_err());
-        assert!(VonMises::new(100.0, 1.0).is_err());
-    }
-
-    #[test]
     fn mean() {
         let m1: f64 = VonMises::new(0.0, 1.0).unwrap().mean().unwrap();
         assert::close(m1, 0.0, TOL);

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -85,7 +85,11 @@ impl VonMises {
             Err(VonMisesError::KNotFinite { k })
         } else {
             let log_i0_k = bessel::log_i0(k);
-            Ok(VonMises { mu: mu % (2.0 * PI), k, log_i0_k })
+            Ok(VonMises {
+                mu: mu % (2.0 * PI),
+                k,
+                log_i0_k,
+            })
         }
     }
 
@@ -144,7 +148,7 @@ impl VonMises {
     pub fn set_mu(&mut self, mu: f64) -> Result<(), VonMisesError> {
         if !mu.is_finite() {
             Err(VonMisesError::MuNotFinite { mu })
-        } else  {
+        } else {
             self.set_mu_unchecked(mu % (2.0 * PI));
             Ok(())
         }

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -137,9 +137,6 @@ impl VonMises {
     /// assert!(vm.set_mu(0.0).is_ok());
     /// assert!(vm.set_mu(2.0 * std::f64::consts::PI).is_ok());
     ///
-    /// assert!(vm.set_mu(0.0 - 0.001).is_err());
-    /// assert!(vm.set_mu(2.0 * std::f64::consts::PI + 0.001).is_err());
-    ///
     /// assert!(vm.set_mu(f64::NEG_INFINITY).is_err());
     /// assert!(vm.set_mu(f64::INFINITY).is_err());
     /// assert!(vm.set_mu(f64::NAN).is_err());

--- a/src/test.rs
+++ b/src/test.rs
@@ -543,8 +543,8 @@ where
     // Fill histogram with samples
     for &sample in samples {
         let u = (sample - min_val) / range; // 0 ≤ u ≤ 1
-        let histix = (u * num_bins as f64) as usize;
-        hist[histix] += 1;
+        let bin_ix = ((u * num_bins as f64) as usize).min(num_bins - 1);
+        hist[bin_ix] += 1;
     }
 
     // Calculate bin width for Simpson's rule

--- a/src/test.rs
+++ b/src/test.rs
@@ -607,3 +607,59 @@ where
 
     Ok(p_value)
 }
+
+mod tests {
+    use super::*;
+    use crate::dist::Exponential;
+    use crate::dist::Gaussian;
+    use crate::traits::HasDensity;
+    use crate::traits::Sampleable;
+    use rand::SeedableRng;
+    use rand_xoshiro::Xoshiro256Plus;
+
+    #[test]
+    fn test_density_histogram_gaussian() {
+        let mut rng = Xoshiro256Plus::seed_from_u64(1);
+        let dist = Gaussian::default();
+
+        // Generate samples from standard normal
+        let n = 1_000_000;
+        let n_bins = 1000;
+        let samples: Vec<f64> = (0..n).map(|_| dist.draw(&mut rng)).collect();
+
+        // Test against standard normal density function
+        let density_fn = |x: f64| dist.f(&x);
+
+        for normalized in [true, false] {
+            let p_value = density_histogram_test(
+                &samples, n_bins, density_fn, normalized,
+            )
+            .unwrap();
+
+            assert!(p_value > 0.05);
+        }
+    }
+
+    #[test]
+    fn test_density_histogram_exponential() {
+        let mut rng = Xoshiro256Plus::seed_from_u64(1);
+        let dist = Exponential::default();
+
+        // Generate samples from standard normal
+        let n = 1_000_000;
+        let n_bins = 1000;
+        let samples: Vec<f64> = (0..n).map(|_| dist.draw(&mut rng)).collect();
+
+        // Test against standard normal density function
+        let density_fn = |x: f64| dist.f(&x);
+
+        for normalized in [true, false] {
+            let p_value = density_histogram_test(
+                &samples, n_bins, density_fn, normalized,
+            )
+            .unwrap();
+
+            assert!(p_value > 0.05);
+        }
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -623,8 +623,8 @@ mod tests {
         let dist = Gaussian::default();
 
         // Generate samples from standard normal
-        let n = 1_000_000;
-        let n_bins = 1000;
+        let n = 10_000;
+        let n_bins = 100;
         let samples: Vec<f64> = (0..n).map(|_| dist.draw(&mut rng)).collect();
 
         // Test against standard normal density function
@@ -646,8 +646,8 @@ mod tests {
         let dist = Exponential::default();
 
         // Generate samples from standard normal
-        let n = 1_000_000;
-        let n_bins = 1000;
+        let n = 10_000;
+        let n_bins = 100;
         let samples: Vec<f64> = (0..n).map(|_| dist.draw(&mut rng)).collect();
 
         // Test against standard normal density function

--- a/src/test.rs
+++ b/src/test.rs
@@ -505,3 +505,98 @@ macro_rules! test_conjugate_prior {
         }
     };
 }
+
+
+use crate::prelude::ChiSquared;
+use crate::traits::Cdf; 
+/// # Arguments
+/// * `samples` - The data samples to test
+/// * `density_fn` - A function that returns the unnormalized density at a given point
+/// * `num_bins` - Number of constant-width bins to use
+/// 
+/// # Returns
+/// * A tuple containing (chi_square_statistic, p_value, degrees_of_freedom)
+pub fn density_histogram_test<F>(
+    samples: &[f64],
+    num_bins: usize,
+    density_fn: F,
+) -> Result<f64, Box<dyn std::error::Error>>
+where
+    F: Fn(f64) -> f64,
+{
+    if samples.is_empty() {
+        return Err("Sample set is empty".into());
+    }
+    if num_bins < 2 {
+        return Err("Need at least 2 bins for chi-square test".into());
+    }
+
+    // Find min and max of the samples
+    let min_val = samples.iter().fold(f64::INFINITY, |a, &b| a.min(b));
+    let max_val = samples.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b));
+    let range = max_val - min_val;
+    
+    // Create histogram with constant width bins
+    let mut hist: Vec<usize> = vec![0; num_bins];
+    
+    // Fill histogram with samples
+    for &sample in samples {
+        let u = (sample - min_val) / range; // 0 ≤ u ≤ 1
+        let histix = (u * num_bins as f64) as usize;
+        hist[histix] += 1;
+    }
+    
+    // Calculate bin width for Simpson's rule
+    let bin_width = (max_val - min_val) / num_bins as f64;
+    
+    // Calculate expected frequencies using Simpson's rule to integrate the density function
+    let mut expected_counts = Vec::with_capacity(num_bins);
+    let mut total_integral = 0.0;
+    
+    for bin_ix in 0..num_bins {
+        let bin_start = min_val + bin_ix as f64 * bin_width;
+        let bin_mid = bin_start + bin_width / 2.0;
+        let bin_end = bin_start + bin_width;
+        
+        // Apply Simpson's rule for each bin
+        let integral = (bin_width / 6.0) * 
+            (density_fn(bin_start) + 4.0 * density_fn(bin_mid) + density_fn(bin_end));
+        
+        expected_counts.push(integral);
+        total_integral += integral;
+    }
+    
+    // Scale the expected counts so the total matches the number of samples
+    let scale_factor = samples.len() as f64 / total_integral;
+    for expected in &mut expected_counts {
+        *expected *= scale_factor;
+    }
+    
+    // Calculate chi-square statistic
+    let mut test_stat = 0.0;
+    let mut valid_bins = 0;
+    
+    for bin_ix in 0..num_bins {
+        let observed = hist[bin_ix];
+        let expected = expected_counts[bin_ix];
+        
+        // Skip bins with expected count less than 5 (chi-square assumption)
+        if expected >= 5.0 {
+            test_stat += (observed as f64 - expected).powi(2) / expected;
+            valid_bins += 1;
+        }
+    }
+    
+    // Degrees of freedom = number of bins - 1
+    let df = valid_bins - 1;
+    
+    if df <= 0 {
+        return Err("Not enough valid bins (with expected count >= 5) for chi-square test".into());
+    }
+    
+    // Calculate p-value
+    let chi_dist = ChiSquared::new(df as f64)?;
+    let p_value = 1.0 - chi_dist.cdf(&test_stat);
+    
+    Ok(p_value)
+}


### PR DESCRIPTION
Added
```rust
pub fn density_histogram_test<F>(
    samples: &[f64],
    num_bins: usize,
    density_fn: F,
    normalized: bool,
) -> Result<f64, Box<dyn std::error::Error>>
```

This is for testing that a sampling algorithm agrees with the density, for cases where there's no available (forward or inverse) CDF. Setting the `normalized` argument to false rescales the density so this can be used for cases where the density is unnormalized.