### PR TITLE
use sin_cos() instead of each separately

### DIFF
--- a/src/data/stat/cdvm.rs
+++ b/src/data/stat/cdvm.rs
@@ -15,10 +15,10 @@ pub struct CdvmSuffStat {
     modulus: usize,
     /// Number of observations
     n: usize,
-    /// ∑ⱼ cos(2πxⱼ/m)
-    sum_cos: f64,
     /// ∑ⱼ sin(2πxⱼ/m)
     sum_sin: f64,
+    /// ∑ⱼ cos(2πxⱼ/m)
+    sum_cos: f64,
 
     /// Cached 2π/m
     #[cfg_attr(feature = "serde1", serde(skip))]
@@ -31,8 +31,8 @@ impl CdvmSuffStat {
         CdvmSuffStat {
             modulus,
             n: 0,
-            sum_cos: 0.0,
             sum_sin: 0.0,
+            sum_cos: 0.0,
             twopi_over_m: 2.0 * std::f64::consts::PI / modulus as f64,
         }
     }
@@ -49,8 +49,8 @@ impl CdvmSuffStat {
         CdvmSuffStat {
             modulus,
             n,
-            sum_cos,
             sum_sin,
+            sum_cos,
             twopi_over_m: 2.0 * std::f64::consts::PI / modulus as f64,
         }
     }
@@ -101,8 +101,9 @@ impl SuffStat<usize> for CdvmSuffStat {
             panic!("x must be less than modulus");
         }
         let angle = self.twopi_over_m * (*x as f64);
-        self.sum_cos += angle.cos();
-        self.sum_sin += angle.sin();
+        let (sin_x, cos_x) = angle.sin_cos();
+        self.sum_sin += sin_x;
+        self.sum_cos += cos_x;
         self.n += 1;
     }
 
@@ -111,8 +112,9 @@ impl SuffStat<usize> for CdvmSuffStat {
             panic!("x must be less than modulus");
         }
         let angle = self.twopi_over_m * (*x as f64);
-        self.sum_cos -= angle.cos();
-        self.sum_sin -= angle.sin();
+        let (sin_x, cos_x) = angle.sin_cos();
+        self.sum_sin -= sin_x;
+        self.sum_cos -= cos_x;
         self.n -= 1;
     }
 

--- a/src/data/stat/vonmises.rs
+++ b/src/data/stat/vonmises.rs
@@ -13,10 +13,10 @@ use crate::traits::SuffStat;
 pub struct VonMisesSuffStat {
     /// Number of observations
     n: usize,
-    /// ∑ⱼ cos(xⱼ)
-    sum_cos: f64,
     /// ∑ⱼ sin(xⱼ)
     sum_sin: f64,
+    /// ∑ⱼ cos(xⱼ)
+    sum_cos: f64,
 }
 
 impl VonMisesSuffStat {
@@ -24,8 +24,8 @@ impl VonMisesSuffStat {
     pub fn new() -> Self {
         VonMisesSuffStat {
             n: 0,
-            sum_cos: 0.0,
             sum_sin: 0.0,
+            sum_cos: 0.0,
         }
     }
 
@@ -35,8 +35,8 @@ impl VonMisesSuffStat {
     pub fn from_parts_unchecked(n: usize, sum_cos: f64, sum_sin: f64) -> Self {
         VonMisesSuffStat {
             n,
-            sum_cos,
             sum_sin,
+            sum_cos,
         }
     }
 
@@ -98,14 +98,16 @@ impl SuffStat<f64> for VonMisesSuffStat {
     }
 
     fn observe(&mut self, x: &f64) {
-        self.sum_cos += x.cos();
-        self.sum_sin += x.sin();
+        let (sin_x, cos_x) = x.sin_cos();
+        self.sum_sin += sin_x;
+        self.sum_cos += cos_x;
         self.n += 1;
     }
 
     fn forget(&mut self, x: &f64) {
-        self.sum_cos -= x.cos();
-        self.sum_sin -= x.sin();
+        let (sin_x, cos_x) = x.sin_cos();
+        self.sum_sin -= sin_x;
+        self.sum_cos -= cos_x;
         self.n -= 1;
     }
 
@@ -114,8 +116,8 @@ impl SuffStat<f64> for VonMisesSuffStat {
             return;
         }
         self.n += other.n;
-        self.sum_cos += other.sum_cos;
         self.sum_sin += other.sum_sin;
+        self.sum_cos += other.sum_cos;
     }
 }
 

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -242,9 +242,10 @@ impl HasSuffStat<usize> for Cdvm {
         let twopimu_over_m = self.mu * self.twopi_over_m();
         // TODO: Should we cache twopimu_over_m.cos() and twopimu_over_m.sin()?
 
+        let (sin_twopimu_over_m, cos_twopimu_over_m) = twopimu_over_m.sin_cos();
         self.kappa
-            * (stat.sum_cos() * twopimu_over_m.cos()
-                + stat.sum_sin() * twopimu_over_m.sin())
+            * (stat.sum_cos() * cos_twopimu_over_m
+                + stat.sum_sin() * sin_twopimu_over_m)
             - stat.n() as f64 * self.log_norm_const()
     }
 }

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -40,6 +40,10 @@ pub struct VonMises {
     // bessel:i0(k), save some cycles
     #[cfg_attr(feature = "serde1", serde(skip))]
     log_i0_k: f64,
+    #[cfg_attr(feature = "serde1", serde(skip))]
+    sin_mu: f64,
+    #[cfg_attr(feature = "serde1", serde(skip))]
+    cos_mu: f64,
 }
 
 pub struct VonMisesParameters {
@@ -84,11 +88,15 @@ impl VonMises {
         } else if !k.is_finite() {
             Err(VonMisesError::KNotFinite { k })
         } else {
+            let mu = mu % (2.0 * PI);
             let log_i0_k = bessel::log_i0(k);
+            let (sin_mu, cos_mu) = mu.sin_cos();
             Ok(VonMises {
-                mu: mu % (2.0 * PI),
+                mu,
                 k,
                 log_i0_k,
+                sin_mu,
+                cos_mu,
             })
         }
     }
@@ -98,7 +106,14 @@ impl VonMises {
     #[inline]
     pub fn new_unchecked(mu: f64, k: f64) -> Self {
         let log_i0_k = bessel::log_i0(k);
-        VonMises { mu, k, log_i0_k }
+        let (sin_mu, cos_mu) = mu.sin_cos();
+        VonMises {
+            mu,
+            k,
+            log_i0_k,
+            sin_mu,
+            cos_mu,
+        }
     }
 
     /// Get the mean parameter, mu

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -130,6 +130,14 @@ impl VonMises {
         self.mu
     }
 
+    pub fn sin_mu(&self) -> f64 {
+        self.sin_mu
+    }
+
+    pub fn cos_mu(&self) -> f64 {
+        self.cos_mu
+    }
+
     /// Set the value of mu
     ///
     /// # Example


### PR DESCRIPTION
- Add `sin_mu` and `cos_mu` fields to `VonMises` to avoid recomputation
- Add `sin_mu` and `cos_mu` methods
- Change separate calls to `.sin()` and `.cos()` to `.sin_cos()`
- Put `sin` before `cos`