### PR TITLE
von Mises bug fixes and test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -180,6 +180,9 @@ impl VonMises {
     #[inline]
     pub fn set_mu_unchecked(&mut self, mu: f64) {
         self.mu = mu;
+        let (sin_mu, cos_mu) = mu.sin_cos();
+        self.sin_mu = sin_mu;
+        self.cos_mu = cos_mu;
     }
 
     /// Get the precision parameter, k

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -314,11 +314,11 @@ macro_rules! impl_traits {
             //     von Mises distribution. Applied Statistics, 152-157.
             // https://www.researchgate.net/publication/246035131_Efficient_Simulation_of_the_von_Mises_Distribution
             fn draw<R: Rng>(&self, rng: &mut R) -> $kind {
-                let x = if self.k.is_zero() {
-                    rng.gen_range(0.0..=2.0 * PI)
+                if self.k.is_zero() {
+                    rng.gen_range(0.0..=2.0 * PI) as $kind
                 } else if self.k > 700.0 {
                     let normal = Normal::new(self.mu, 1.0 / self.k).unwrap();
-                    rng.sample(normal)
+                    rng.sample(normal).rem_euclid(2.0 * PI) as $kind
                 } else {
                     let tau =
                         1.0 + 4.0_f64.mul_add(self.k * self.k, 1.0).sqrt();
@@ -349,13 +349,14 @@ macro_rules! impl_traits {
                     }
 
                     let acf = f.acos();
-                    if rng.gen_bool(0.5) {
+                    let x = if rng.gen_bool(0.5) {
                         self.mu + acf
                     } else {
                         self.mu - acf
-                    }
-                };
-                x.rem_euclid(2.0 * PI) as $kind
+                    };
+                    x.rem_euclid(2.0 * PI) as $kind
+                }
+                
             }
         }
 

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -306,10 +306,10 @@ macro_rules! impl_traits {
             // https://www.researchgate.net/publication/246035131_Efficient_Simulation_of_the_von_Mises_Distribution
             fn draw<R: Rng>(&self, rng: &mut R) -> $kind {
                 let x = if self.k.is_zero() {
-                    rng.gen_range(0.0..=2.0 * PI) 
+                    rng.gen_range(0.0..=2.0 * PI)
                 } else if self.k > 700.0 {
                     let normal = Normal::new(self.mu, 1.0 / self.k).unwrap();
-                    rng.sample(normal) 
+                    rng.sample(normal)
                 } else {
                     let tau =
                         1.0 + 4.0_f64.mul_add(self.k * self.k, 1.0).sqrt();
@@ -345,7 +345,6 @@ macro_rules! impl_traits {
                     } else {
                         self.mu - acf
                     }
-                    
                 };
                 x.rem_euclid(2.0 * PI) as $kind
             }
@@ -452,10 +451,10 @@ mod tests {
     use crate::misc::ks_test;
     use crate::test::density_histogram_test;
     use crate::test_basic_impls;
-    
-    use rand_xoshiro::Xoshiro256Plus;
-    use rand::SeedableRng;
+
     use proptest::prelude::*;
+    use rand::SeedableRng;
+    use rand_xoshiro::Xoshiro256Plus;
 
     const TOL: f64 = 1E-12;
     const KS_PVAL: f64 = 0.2;
@@ -572,7 +571,6 @@ mod tests {
         assert!(xs.iter().all(|x| vm.supports(x)));
     }
 
-    // TODO: Why is this failing?
     #[test]
     fn vm_draw_test() {
         let mut rng = rand::thread_rng();
@@ -647,7 +645,6 @@ mod tests {
         assert!(p_value > 0.01);
     }
 
-
     proptest! {
         #[test]
         fn vonmises_draw_produces_valid_range(
@@ -657,9 +654,9 @@ mod tests {
         ) {
             let vm = VonMises::new(mu, k).unwrap();
             let mut rng = Xoshiro256Plus::seed_from_u64(seed);
-            
+
             let sample: f64 = vm.draw(&mut rng);
-            
+
             prop_assert!(
                 sample >= 0.0 && sample < 2.0 * std::f64::consts::PI,
                 "Sample {} not in range [0, 2π) for VonMises({}, {})",

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -355,7 +355,6 @@ macro_rules! impl_traits {
                     };
                     x.rem_euclid(2.0 * PI) as $kind
                 }
-                
             }
         }
 

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -289,7 +289,7 @@ impl VonMises {
 
 impl Default for VonMises {
     fn default() -> Self {
-        VonMises::new(PI, 1.0).unwrap()
+        VonMises::new(0.0, 0.0).unwrap()
     }
 }
 

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -662,23 +662,23 @@ mod tests {
         let mu = 1.5;
         let k = 2.0;
         let vm = VonMises::new(mu, k).unwrap();
-        
+
         // 1. Generate a sample
         let sample_size = 100;
         let xs: Vec<f64> = vm.sample(sample_size, &mut rng);
-        
+
         // 2. Find the ln_f of the sample (direct log-likelihood)
         let ln_f_sum: f64 = xs.iter().map(|x| vm.ln_f(x)).sum();
-        
+
         // 3. Aggregate the sample into a suffstat
         let mut stat = vm.empty_suffstat();
         for x in &xs {
             stat.observe(x);
         }
-        
+
         // 4. Compute ln_f_stat
         let ln_f_stat_result = vm.ln_f_stat(&stat);
-        
+
         // 5. Assert that they are close
         assert::close(ln_f_sum, ln_f_stat_result, 1e-10);
     }

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -11,7 +11,6 @@ use rand::Rng;
 use rand_distr::Normal;
 use std::f64::consts::PI;
 use std::fmt;
-use std::sync::OnceLock;
 
 /// [VonMises distribution](https://en.wikipedia.org/wiki/Von_Mises_distribution)
 /// on the circular interval [0, 2π)

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -13,7 +13,7 @@ use std::f64::consts::PI;
 use std::fmt;
 
 /// [VonMises distribution](https://en.wikipedia.org/wiki/Von_Mises_distribution)
-/// on the circular interval (0, 2π]
+/// on the circular interval [0, 2π)
 ///
 /// # Example
 ///


### PR DESCRIPTION
Updated `vonmises.rs`:
- Some bug fixes
- Made `log_i0_k: OnceLock<f64>`
- Implemented `PartialEq`
- Changed `%` to `rem_euclid`
- Added tests
- CDF test now passes! :partying_face: 

Also needed `cargo update crossbeam-channel` - apparently some issue fixed by new version