### PR TITLE
Make ConjugatePrior use SuffStat directly

### DIFF
--- a/examples/dpgmm.rs
+++ b/examples/dpgmm.rs
@@ -42,7 +42,7 @@ use std::sync::Arc;
 struct Dpmm<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: LegacyConjugatePrior<X, Fx>,
 {
     // The data
     xs: Vec<X>,
@@ -61,7 +61,7 @@ where
 impl<X, Fx, Pr> Dpmm<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: LegacyConjugatePrior<X, Fx>,
 {
     // Draws a Dpmm from the prior
     fn new<R: Rng>(xs: Vec<X>, prior: Pr, alpha: f64, rng: &mut R) -> Self {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -21,7 +21,7 @@ pub use stat::VonMisesSuffStat;
 use crate::dist::{
     Bernoulli, Categorical, Gaussian, InvGamma, InvGaussian, Poisson,
 };
-use crate::traits::ConjugatePrior;
+use crate::traits::LegacyConjugatePrior;
 use crate::traits::HasDensity;
 use crate::traits::{HasSuffStat, SuffStat};
 
@@ -222,7 +222,7 @@ pub fn extract_stat<X, Fx, Pr>(pr: &Pr, x: &DataOrSuffStat<X, Fx>) -> Fx::Stat
 where
     Fx: HasSuffStat<X> + HasDensity<X>,
     Fx::Stat: Clone,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: LegacyConjugatePrior<X, Fx>,
 {
     match x {
         DataOrSuffStat::SuffStat(s) => (*s).clone(),
@@ -243,7 +243,7 @@ pub fn extract_stat_then<X, Fx, Pr, Fnx, Y>(
 where
     Fx: HasSuffStat<X> + HasDensity<X>,
     Fx::Stat: Clone,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: LegacyConjugatePrior<X, Fx>,
     Fnx: Fn(Fx::Stat) -> Y,
 {
     let stat = extract_stat(pr, x);
@@ -519,7 +519,7 @@ mod tests {
         use crate::data::GaussianSuffStat;
         use crate::dist::Gaussian;
         use crate::traits::{
-            ConjugatePrior, HasSuffStat, Sampleable, SuffStat,
+            LegacyConjugatePrior, HasSuffStat, Sampleable, SuffStat,
         };
         use rand::Rng;
 
@@ -542,7 +542,7 @@ mod tests {
             }
         }
 
-        impl ConjugatePrior<f64, Gaussian> for MockConjPrior {
+        impl LegacyConjugatePrior<f64, Gaussian> for MockConjPrior {
             type Posterior = MockPosterior;
             type MCache = ();
             type PpCache = ();

--- a/src/dist/beta/bernoulli_prior.rs
+++ b/src/dist/beta/bernoulli_prior.rs
@@ -26,7 +26,7 @@ impl Support<Bernoulli> for Beta {
 
 impl ContinuousDistr<Bernoulli> for Beta {}
 
-impl<X: Booleable> ConjugatePrior<X, Bernoulli> for Beta {
+impl<X: Booleable> LegacyConjugatePrior<X, Bernoulli> for Beta {
     type Posterior = Self;
     type MCache = f64;
     type PpCache = (f64, f64);

--- a/src/dist/betaprime.rs
+++ b/src/dist/betaprime.rs
@@ -282,7 +282,7 @@ use crate::data::DataOrSuffStat;
 use crate::experimental::stick_breaking_process::{
     StickBreakingDiscrete, StickBreakingDiscreteSuffStat,
 };
-use crate::traits::ConjugatePrior;
+use crate::traits::LegacyConjugatePrior;
 
 #[cfg(feature = "experimental")]
 use crate::experimental::stick_breaking_process::StickBreaking;
@@ -373,7 +373,7 @@ impl fmt::Display for BetaPrimeError {
 }
 
 #[cfg(feature = "experimental")]
-impl ConjugatePrior<usize, StickBreakingDiscrete> for BetaPrime {
+impl LegacyConjugatePrior<usize, StickBreakingDiscrete> for BetaPrime {
     type Posterior = Self;
     type MCache = f64;
     type PpCache = f64;

--- a/src/dist/dirichlet/categorical_prior.rs
+++ b/src/dist/dirichlet/categorical_prior.rs
@@ -19,7 +19,7 @@ impl Sampleable<Categorical> for SymmetricDirichlet {
     }
 }
 
-impl<X: CategoricalDatum> ConjugatePrior<X, Categorical>
+impl<X: CategoricalDatum> LegacyConjugatePrior<X, Categorical>
     for SymmetricDirichlet
 {
     type Posterior = Dirichlet;
@@ -91,7 +91,7 @@ impl Sampleable<Categorical> for Dirichlet {
     }
 }
 
-impl<X: CategoricalDatum> ConjugatePrior<X, Categorical> for Dirichlet {
+impl<X: CategoricalDatum> LegacyConjugatePrior<X, Categorical> for Dirichlet {
     type Posterior = Self;
     type MCache = (f64, f64);
     type PpCache = (Vec<f64>, f64);

--- a/src/dist/gamma/poisson_prior.rs
+++ b/src/dist/gamma/poisson_prior.rs
@@ -41,7 +41,7 @@ impl ContinuousDistr<Poisson> for Gamma {}
 
 macro_rules! impl_traits {
     ($kind: ty) => {
-        impl ConjugatePrior<$kind, Poisson> for Gamma {
+        impl LegacyConjugatePrior<$kind, Poisson> for Gamma {
             type Posterior = Self;
             type MCache = f64;
             type PpCache = (f64, f64, f64);

--- a/src/dist/niw/mvg_prior.rs
+++ b/src/dist/niw/mvg_prior.rs
@@ -2,7 +2,7 @@ use crate::consts::LN_2PI;
 use crate::data::{extract_stat_then, DataOrSuffStat, MvGaussianSuffStat};
 use crate::dist::{MvGaussian, NormalInvWishart};
 use crate::misc::lnmv_gamma;
-use crate::traits::ConjugatePrior;
+use crate::traits::LegacyConjugatePrior;
 use crate::traits::HasSuffStat;
 use crate::traits::SuffStat;
 use nalgebra::{DMatrix, DVector};
@@ -21,7 +21,7 @@ fn ln_z(k: f64, df: usize, scale: &DMatrix<f64>) -> f64 {
         )
 }
 
-impl ConjugatePrior<DVector<f64>, MvGaussian> for NormalInvWishart {
+impl LegacyConjugatePrior<DVector<f64>, MvGaussian> for NormalInvWishart {
     type Posterior = Self;
     type MCache = f64;
     type PpCache = (Self, f64);

--- a/src/dist/normal_gamma/gaussian_prior.rs
+++ b/src/dist/normal_gamma/gaussian_prior.rs
@@ -48,7 +48,7 @@ fn posterior_from_stat(
     PosteriorParameters { m, r, s, v }
 }
 
-impl ConjugatePrior<f64, Gaussian> for NormalGamma {
+impl LegacyConjugatePrior<f64, Gaussian> for NormalGamma {
     type Posterior = Self;
     type MCache = f64;
     type PpCache = (PosteriorParameters, f64);

--- a/src/dist/normal_inv_chi_squared/gaussian_prior.rs
+++ b/src/dist/normal_inv_chi_squared/gaussian_prior.rs
@@ -60,7 +60,7 @@ fn posterior_from_stat(
     PosteriorParameters { mn, kn, vn, s2n }
 }
 
-impl ConjugatePrior<f64, Gaussian> for NormalInvChiSquared {
+impl LegacyConjugatePrior<f64, Gaussian> for NormalInvChiSquared {
     type Posterior = Self;
     type MCache = f64;
     type PpCache = (PosteriorParameters, f64);

--- a/src/dist/normal_inv_gamma/gaussian_prior.rs
+++ b/src/dist/normal_inv_gamma/gaussian_prior.rs
@@ -56,7 +56,7 @@ fn posterior_from_stat(
     }
 }
 
-impl ConjugatePrior<f64, Gaussian> for NormalInvGamma {
+impl LegacyConjugatePrior<f64, Gaussian> for NormalInvGamma {
     type Posterior = Self;
     type MCache = f64;
     type PpCache = (PosteriorParameters, f64);
@@ -146,7 +146,7 @@ mod test {
     }
 
     // Random reference I found using the same source
-    // https://github.com/JuliaStats/ConjugatePriors.jl/blob/master/src/normalinversegamma.jl
+    // https://github.com/JuliaStats/LegacyConjugatePriors.jl/blob/master/src/normalinversegamma.jl
     fn ln_f_ref(gauss: &Gaussian, nig: &NormalInvGamma) -> f64 {
         let NormalInvGammaParameters { m, v, a, b } = nig.emit_params();
         let mu = gauss.mu();

--- a/src/dist/unit_powerlaw/bernoulli_prior.rs
+++ b/src/dist/unit_powerlaw/bernoulli_prior.rs
@@ -26,7 +26,7 @@ impl Support<Bernoulli> for UnitPowerLaw {
 
 impl ContinuousDistr<Bernoulli> for UnitPowerLaw {}
 
-impl<X: Booleable> ConjugatePrior<X, Bernoulli> for UnitPowerLaw {
+impl<X: Booleable> LegacyConjugatePrior<X, Bernoulli> for UnitPowerLaw {
     type Posterior = Beta;
     type MCache = f64;
     type PpCache = (f64, f64);

--- a/src/experimental/stick_breaking_process/stick_breaking.rs
+++ b/src/experimental/stick_breaking_process/stick_breaking.rs
@@ -236,8 +236,8 @@ impl Sampleable<StickBreakingDiscrete> for StickBreaking {
     }
 }
 
-/// Implementation of the `ConjugatePrior` trait for the `StickBreaking` struct.
-impl ConjugatePrior<usize, StickBreakingDiscrete> for StickBreaking {
+/// Implementation of the `LegacyConjugatePrior` trait for the `StickBreaking` struct.
+impl LegacyConjugatePrior<usize, StickBreakingDiscrete> for StickBreaking {
     type Posterior = StickBreaking;
     type MCache = ();
     type PpCache = Self::Posterior;

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,9 +14,9 @@ use std::sync::Arc;
 pub struct ConjugateModel<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: LegacyConjugatePrior<X, Fx>,
 {
-    /// Pointer to an `Rv` implementing `ConjugatePrior` for `Fx`
+    /// Pointer to an `Rv` implementing `LegacyConjugatePrior` for `Fx`
     prior: Arc<Pr>,
     /// A `SuffStat` for `Fx`
     suffstat: Fx::Stat,
@@ -26,7 +26,7 @@ where
 impl<X, Fx, Pr> ConjugateModel<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: LegacyConjugatePrior<X, Fx>,
 {
     /// Create a new conjugate model
     ///
@@ -96,7 +96,7 @@ where
 impl<X, Fx, Pr> SuffStat<X> for ConjugateModel<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: LegacyConjugatePrior<X, Fx>,
 {
     fn n(&self) -> usize {
         self.suffstat.n()
@@ -118,7 +118,7 @@ where
 impl<X, Fx, Pr> HasDensity<X> for ConjugateModel<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: LegacyConjugatePrior<X, Fx>,
 {
     fn ln_f(&self, x: &X) -> f64 {
         self.prior.ln_pp(x, &self.obs())
@@ -128,7 +128,7 @@ where
 impl<X, Fx, Pr> Sampleable<X> for ConjugateModel<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: LegacyConjugatePrior<X, Fx>,
 {
     fn draw<R: Rng>(&self, mut rng: &mut R) -> X {
         let post = self.posterior();

--- a/src/test.rs
+++ b/src/test.rs
@@ -322,7 +322,7 @@ macro_rules! gaussian_prior_geweke_testable {
                 data: &[f64],
                 rng: &mut R,
             ) -> Gaussian {
-                let post = <$prior as ConjugatePrior<f64, $fx>>::posterior(
+                let post = <$prior as LegacyConjugatePrior<f64, $fx>>::posterior(
                     &self,
                     &DataOrSuffStat::from(data),
                 );
@@ -416,19 +416,19 @@ macro_rules! test_conjugate_prior {
 
                 let y: $X = fx.draw(&mut rng);
 
-                let ln_pp = <$Pr as ConjugatePrior<$X, $Fx>>::ln_pp(
+                let ln_pp = <$Pr as LegacyConjugatePrior<$X, $Fx>>::ln_pp(
                     &pr,
                     &y,
                     &DataOrSuffStat::SuffStat(&stat),
                 );
-                let ln_m_lower = <$Pr as ConjugatePrior<$X, $Fx>>::ln_m(
+                let ln_m_lower = <$Pr as LegacyConjugatePrior<$X, $Fx>>::ln_m(
                     &pr,
                     &DataOrSuffStat::SuffStat(&stat),
                 );
 
                 stat.observe(&y);
 
-                let ln_m_upper = <$Pr as ConjugatePrior<$X, $Fx>>::ln_m(
+                let ln_m_upper = <$Pr as LegacyConjugatePrior<$X, $Fx>>::ln_m(
                     &pr,
                     &DataOrSuffStat::SuffStat(&stat),
                 );
@@ -455,12 +455,12 @@ macro_rules! test_conjugate_prior {
                         &fx, &stat,
                     );
                 let ln_prior = pr.ln_f(&fx);
-                let ln_m = <$Pr as ConjugatePrior<$X, $Fx>>::ln_m(
+                let ln_m = <$Pr as LegacyConjugatePrior<$X, $Fx>>::ln_m(
                     &pr,
                     &DataOrSuffStat::SuffStat(&stat),
                 );
 
-                let posterior = <$Pr as ConjugatePrior<$X, $Fx>>::posterior(
+                let posterior = <$Pr as LegacyConjugatePrior<$X, $Fx>>::posterior(
                     &pr,
                     &DataOrSuffStat::SuffStat(&stat),
                 );
@@ -492,7 +492,7 @@ macro_rules! test_conjugate_prior {
 
                 let stat = random_xs(&pr.draw(&mut rng), 3, &mut rng);
 
-                let m = <$Pr as ConjugatePrior<$X, $Fx>>::m(
+                let m = <$Pr as LegacyConjugatePrior<$X, $Fx>>::m(
                     &pr,
                     &DataOrSuffStat::SuffStat(&stat),
                 );

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -605,6 +605,85 @@ where
     }
 }
 
+
+
+pub trait ConjugatePrior<X, Fx>: Sampleable<Fx>
+where
+    Fx: HasDensity<X> + HasSuffStat<X>,
+{
+    /// Type of the posterior distribution
+    type Posterior: Sampleable<Fx>;
+    /// Type of the cache for the marginal likelihood
+    type MCache;
+    /// Type of the cache for the posterior predictive
+    type PpCache;
+
+    /// Generate and empty sufficient statistic
+    fn empty_stat(&self) -> Fx::Stat;
+
+
+    fn posterior(&self, stat: &Fx::Stat) -> Self::Posterior;
+
+    /// Compute the cache for the log marginal likelihood.
+    fn ln_m_cache(&self) -> Self::MCache;
+
+    /// Log marginal likelihood with supplied cache.
+    fn ln_m_with_cache(
+        &self,
+        cache: &Self::MCache,
+        stat: &Fx::Stat,
+    ) -> f64;
+
+    /// The log marginal likelihood
+    fn ln_m(&self, x: &Fx::Stat) -> f64 {
+        let cache = self.ln_m_cache();
+        self.ln_m_with_cache(&cache, x)
+    }
+
+    /// Compute the cache for the Log posterior predictive of y given x.
+    ///
+    /// The cache should encompass all information about `x`.
+    fn ln_pp_cache(&self, stat: &Fx::Stat) -> Self::PpCache;
+
+    /// Log posterior predictive of y given x with supplied ln(norm)
+    fn ln_pp_with_cache(&self, cache: &Self::PpCache, y: &X) -> f64;
+
+    /// Log posterior predictive of y given x
+    fn ln_pp(&self, y: &X, stat: &Fx::Stat) -> f64 {
+        let cache = self.ln_pp_cache(stat);
+        self.ln_pp_with_cache(&cache, y)
+    }
+
+    /// Marginal likelihood of x
+    fn m(&self, x: &Fx::Stat) -> f64 {
+        self.ln_m(x).exp()
+    }
+
+    fn pp_with_cache(&self, cache: &Self::PpCache, y: &X) -> f64 {
+        self.ln_pp_with_cache(cache, y).exp()
+    }
+
+    /// Posterior Predictive distribution
+    fn pp(&self, y: &X, x: &Fx::Stat) -> f64 {
+        self.ln_pp(y, x).exp()
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /// Get the quad bounds of a univariate real distribution
 pub trait QuadBounds {
     fn quad_bounds(&self) -> (f64, f64);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -461,7 +461,7 @@ pub trait KlDivergence {
 /// success probability.
 ///
 /// ```
-/// use rv::traits::ConjugatePrior;
+/// use rv::traits::LegacyConjugatePrior;
 /// use rv::dist::{Bernoulli, Beta};
 ///
 /// let flips = vec![true, false, false];
@@ -478,7 +478,7 @@ pub trait KlDivergence {
 /// Use a cache to speed up repeated computations.
 ///
 /// ```
-/// # use rv::traits::ConjugatePrior;
+/// # use rv::traits::LegacyConjugatePrior;
 /// use rv::traits::*;
 /// use rv::traits::SuffStat;
 /// use rv::dist::{Categorical, SymmetricDirichlet};
@@ -539,7 +539,7 @@ pub trait KlDivergence {
 /// // Using cache improves runtime
 /// assert!(t_no_cache.as_nanos() > t_cache.as_nanos());
 /// ```
-pub trait ConjugatePrior<X, Fx>: Sampleable<Fx>
+pub trait LegacyConjugatePrior<X, Fx>: Sampleable<Fx>
 where
     Fx: HasDensity<X> + HasSuffStat<X>,
 {
@@ -653,7 +653,7 @@ pub trait HasSuffStat<X> {
 ///
 /// ```
 /// use rv::traits::SuffStat;
-/// use rv::traits::ConjugatePrior;
+/// use rv::traits::LegacyConjugatePrior;
 /// use rv::data::BernoulliSuffStat;
 /// use rv::dist::{Bernoulli, Beta};
 ///


### PR DESCRIPTION
Exploring having ConjgatePrior use SuffStat directly, rather than requiring DataOrSuffStat, which sometimes seems like extra work