### PR TITLE
ScaledPrior and ShiftedPrior

### DIFF
--- a/benches/vonmises.rs
+++ b/benches/vonmises.rs
@@ -1,17 +1,14 @@
 use criterion::black_box;
-use criterion::measurement::WallTime;
 use criterion::AxisScale;
 use criterion::BatchSize;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::PlotConfiguration;
-use criterion::Throughput;
 use criterion::{criterion_group, criterion_main};
 use rand::Rng;
 use rv::dist::VonMises;
 use rv::misc::bessel::log_i0;
 use rv::prelude::*;
-use rv::traits::*;
 use std::f64::consts::PI;
 
 fn bench_vm_draw(c: &mut Criterion) {

--- a/examples/betaprime_sbc.rs
+++ b/examples/betaprime_sbc.rs
@@ -1,5 +1,3 @@
-use rv::dist::BetaPrime;
-
 #[cfg(feature = "experimental")]
 use rand::SeedableRng;
 #[cfg(feature = "experimental")]
@@ -8,7 +6,6 @@ use rand_xoshiro::Xoshiro256Plus;
 use rv::experimental::stick_breaking_process::{
     StickBreaking, StickBreakingDiscrete, StickBreakingDiscreteSuffStat,
 };
-use rv::prelude::*;
 
 // Simulation-based calibration
 // For details see http://www.stat.columbia.edu/~gelman/research/unpublished/sbc.pdf

--- a/examples/betaprime_sbc.rs
+++ b/examples/betaprime_sbc.rs
@@ -1,16 +1,14 @@
-#[cfg(feature = "experimental")]
-use rand::SeedableRng;
-#[cfg(feature = "experimental")]
-use rand_xoshiro::Xoshiro256Plus;
-#[cfg(feature = "experimental")]
-use rv::experimental::stick_breaking_process::{
-    StickBreaking, StickBreakingDiscrete, StickBreakingDiscreteSuffStat,
-};
-
 // Simulation-based calibration
 // For details see http://www.stat.columbia.edu/~gelman/research/unpublished/sbc.pdf
 #[cfg(feature = "experimental")]
 fn main() {
+    use rand::SeedableRng;
+    use rand_xoshiro::Xoshiro256Plus;
+    use rv::experimental::stick_breaking_process::{
+        StickBreaking, StickBreakingDiscrete, StickBreakingDiscreteSuffStat,
+    };
+    use rv::prelude::*;
+
     let mut rng = Xoshiro256Plus::seed_from_u64(123);
     let n_samples = 10000;
     let n_obs = 10;

--- a/examples/sbd.rs
+++ b/examples/sbd.rs
@@ -1,11 +1,12 @@
-#[cfg(feature = "experimental")]
-use rv::experimental::stick_breaking_process::{
-    StickBreaking, StickBreakingDiscrete, StickSequence,
-};
-
 fn main() {
     #[cfg(feature = "experimental")]
     {
+        use rand_xoshiro::rand_core::SeedableRng;
+        use rv::experimental::stick_breaking_process::{
+            StickBreaking, StickBreakingDiscrete, StickSequence,
+        };
+        use rv::prelude::*;
+
         // Instantiate a stick-breaking process
         let alpha = 10.0;
         let sbp = StickBreaking::new(UnitPowerLaw::new(alpha).unwrap());

--- a/examples/sbd.rs
+++ b/examples/sbd.rs
@@ -1,6 +1,3 @@
-use rand::SeedableRng;
-use rv::prelude::*;
-
 #[cfg(feature = "experimental")]
 use rv::experimental::stick_breaking_process::{
     StickBreaking, StickBreakingDiscrete, StickSequence,

--- a/examples/stickbreaking_posterior.rs
+++ b/examples/stickbreaking_posterior.rs
@@ -1,9 +1,11 @@
-#[cfg(feature = "experimental")]
-use rv::experimental::stick_breaking_process::*;
-
 fn main() {
     #[cfg(feature = "experimental")]
     {
+        use itertools::Either;
+        use peroxide::fuga::Statistics;
+        use rv::experimental::stick_breaking_process::*;
+        use rv::prelude::*;
+
         let mut rng = rand::thread_rng();
         let sb = StickBreaking::new(UnitPowerLaw::new(3.0).unwrap());
 

--- a/examples/stickbreaking_posterior.rs
+++ b/examples/stickbreaking_posterior.rs
@@ -1,7 +1,3 @@
-use itertools::Either;
-use peroxide::statistics::stat::Statistics;
-use rv::prelude::*;
-
 #[cfg(feature = "experimental")]
 use rv::experimental::stick_breaking_process::*;
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -578,7 +578,6 @@ mod tests {
                 &self,
                 _x: &crate::data::GaussianData<f64>,
             ) -> Self::PpCache {
-                ()
             }
 
             fn ln_pp_with_cache(

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -386,8 +386,8 @@ mod tests {
         fn impl_bool_into_bool() {
             let t = true;
             let f = false;
-            assert_eq!(t.into_bool(), true);
-            assert_eq!(f.into_bool(), false);
+            assert!(t.into_bool());
+            assert!(!f.into_bool());
         }
 
         #[test]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -235,7 +235,7 @@ pub fn extract_stat_then<X, Fx, Pr, Fnx, Y>(
 ) -> Y
 where
     Fx: HasSuffStat<X> + HasDensity<X>,
-    Pr: ConjugatePrior<X, Fx>,
+    Pr: ConjugatePrior<X, Fx> + ?Sized,
     Fnx: Fn(&Fx::Stat) -> Y,
 {
     match x {

--- a/src/dist/betaprime.rs
+++ b/src/dist/betaprime.rs
@@ -389,6 +389,7 @@ impl ConjugatePrior<usize, StickBreakingDiscrete> for BetaPrime {
     ) -> Self {
         match data {
             DataOrSuffStat::Data(xs) => {
+                #[allow(clippy::useless_asref)]
                 let stat = StickBreakingDiscreteSuffStat::from(xs.as_ref());
                 self.posterior(&DataOrSuffStat::SuffStat(&stat))
             }

--- a/src/dist/betaprime.rs
+++ b/src/dist/betaprime.rs
@@ -10,6 +10,9 @@ use std::f64;
 use std::fmt;
 use std::sync::OnceLock;
 
+#[cfg(feature = "experimental")]
+use super::UnitPowerLaw;
+
 /// [Beta prime distribution](https://en.wikipedia.org/wiki/Beta_prime_distribution),
 /// BetaPrime(α, β) over x in (0, ∞).
 ///
@@ -277,17 +280,13 @@ impl Sampleable<f64> for BetaPrime {
     }
 }
 
-use crate::data::DataOrSuffStat;
 #[cfg(feature = "experimental")]
 use crate::experimental::stick_breaking_process::{
     StickBreakingDiscrete, StickBreakingDiscreteSuffStat,
 };
-use crate::traits::ConjugatePrior;
 
 #[cfg(feature = "experimental")]
 use crate::experimental::stick_breaking_process::StickBreaking;
-
-use crate::prelude::UnitPowerLaw;
 
 #[cfg(feature = "experimental")]
 impl Sampleable<StickBreakingDiscrete> for BetaPrime {

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -243,10 +243,13 @@ impl HasSuffStat<usize> for Cdvm {
         // TODO: Should we cache twopimu_over_m.cos() and twopimu_over_m.sin()?
 
         let (sin_twopimu_over_m, cos_twopimu_over_m) = twopimu_over_m.sin_cos();
-        self.kappa
-            * (stat.sum_cos() * cos_twopimu_over_m
-                + stat.sum_sin() * sin_twopimu_over_m)
-            - stat.n() as f64 * self.log_norm_const()
+        self.kappa.mul_add(
+            stat.sum_cos().mul_add(
+                cos_twopimu_over_m,
+                stat.sum_sin() * sin_twopimu_over_m,
+            ),
+            -(stat.n() as f64 * self.log_norm_const()),
+        )
     }
 }
 

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -45,6 +45,7 @@ mod pareto;
 mod poisson;
 mod scaled;
 mod scaled_inv_chi_squared;
+mod scaled_prior;
 mod shifted;
 mod skellam;
 mod students_t;
@@ -108,6 +109,7 @@ pub use scaled_inv_chi_squared::{
     ScaledInvChiSquared, ScaledInvChiSquaredError,
     ScaledInvChiSquaredParameters,
 };
+pub use scaled_prior::{ScaledPrior, ScaledPriorError};
 pub use shifted::{Shifted, ShiftedError, ShiftedParameters};
 pub use skellam::{Skellam, SkellamError, SkellamParameters};
 pub use students_t::{StudentsT, StudentsTError, StudentsTParameters};

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -47,6 +47,7 @@ mod scaled;
 mod scaled_inv_chi_squared;
 mod scaled_prior;
 mod shifted;
+mod shifted_prior;
 mod skellam;
 mod students_t;
 mod uniform;
@@ -111,6 +112,7 @@ pub use scaled_inv_chi_squared::{
 };
 pub use scaled_prior::{ScaledPrior, ScaledPriorError};
 pub use shifted::{Shifted, ShiftedError, ShiftedParameters};
+pub use shifted_prior::{ShiftedPrior, ShiftedPriorError};
 pub use skellam::{Skellam, SkellamError, SkellamParameters};
 pub use students_t::{StudentsT, StudentsTError, StudentsTParameters};
 pub use uniform::{Uniform, UniformError, UniformParameters};

--- a/src/dist/normal_gamma/gaussian_prior.rs
+++ b/src/dist/normal_gamma/gaussian_prior.rs
@@ -3,7 +3,7 @@ use std::f64::consts::LN_2;
 
 use super::dos_to_post;
 use crate::consts::*;
-use crate::data::{extract_stat, GaussianSuffStat};
+use crate::data::{extract_stat_then, GaussianSuffStat};
 use crate::dist::{Gaussian, NormalGamma};
 use crate::gaussian_prior_geweke_testable;
 use crate::misc::ln_gammafn;
@@ -77,20 +77,20 @@ impl ConjugatePrior<f64, Gaussian> for NormalGamma {
     }
 
     fn ln_pp_cache(&self, x: &DataOrSuffStat<f64, Gaussian>) -> Self::PpCache {
-        let stat = extract_stat(self, x);
+        extract_stat_then(self, x, |stat| {
+            let params = posterior_from_stat(self, &stat);
+            let PosteriorParameters { r, s, v, .. } = params;
 
-        let params = posterior_from_stat(self, &stat);
-        let PosteriorParameters { r, s, v, .. } = params;
+            let half_v = v / 2.0;
+            let g_ratio = ln_gammafn(half_v + 0.5) - ln_gammafn(half_v);
+            let term = 0.5_f64.mul_add(LN_2, -HALF_LN_2PI)
+                + 0.5_f64.mul_add(
+                    (r / (r + 1_f64)).ln(),
+                    half_v.mul_add(s.ln(), g_ratio),
+                );
 
-        let half_v = v / 2.0;
-        let g_ratio = ln_gammafn(half_v + 0.5) - ln_gammafn(half_v);
-        let term = 0.5_f64.mul_add(LN_2, -HALF_LN_2PI)
-            + 0.5_f64.mul_add(
-                (r / (r + 1_f64)).ln(),
-                half_v.mul_add(s.ln(), g_ratio),
-            );
-
-        (params, term)
+            (params, term)
+        })
     }
 
     fn ln_pp_with_cache(&self, cache: &Self::PpCache, y: &f64) -> f64 {

--- a/src/dist/normal_gamma/gaussian_prior.rs
+++ b/src/dist/normal_gamma/gaussian_prior.rs
@@ -78,7 +78,7 @@ impl ConjugatePrior<f64, Gaussian> for NormalGamma {
 
     fn ln_pp_cache(&self, x: &DataOrSuffStat<f64, Gaussian>) -> Self::PpCache {
         extract_stat_then(self, x, |stat| {
-            let params = posterior_from_stat(self, &stat);
+            let params = posterior_from_stat(self, stat);
             let PosteriorParameters { r, s, v, .. } = params;
 
             let half_v = v / 2.0;

--- a/src/dist/normal_inv_chi_squared/gaussian_prior.rs
+++ b/src/dist/normal_inv_chi_squared/gaussian_prior.rs
@@ -88,7 +88,7 @@ impl ConjugatePrior<f64, Gaussian> for NormalInvChiSquared {
     ) -> f64 {
         extract_stat_then(self, x, |stat: &GaussianSuffStat| {
             let n = stat.n() as f64;
-            let post: Self = posterior_from_stat(self, &stat).into();
+            let post: Self = posterior_from_stat(self, stat).into();
             let lnz_n = post.ln_z();
             n.mul_add(-HALF_LN_PI, lnz_n - cache)
         })
@@ -96,7 +96,7 @@ impl ConjugatePrior<f64, Gaussian> for NormalInvChiSquared {
 
     fn ln_pp_cache(&self, x: &DataOrSuffStat<f64, Gaussian>) -> Self::PpCache {
         extract_stat_then(self, x, |stat: &GaussianSuffStat| {
-            let post = posterior_from_stat(self, &stat);
+            let post = posterior_from_stat(self, stat);
             let kn = post.kn;
             let vn = post.vn;
 

--- a/src/dist/normal_inv_chi_squared/gaussian_prior.rs
+++ b/src/dist/normal_inv_chi_squared/gaussian_prior.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::f64::consts::PI;
 
 use crate::consts::HALF_LN_PI;
-use crate::data::{ extract_stat_then, GaussianSuffStat};
+use crate::data::{extract_stat_then, GaussianSuffStat};
 use crate::dist::{Gaussian, NormalInvChiSquared};
 use crate::gaussian_prior_geweke_testable;
 use crate::misc::ln_gammafn;
@@ -69,10 +69,11 @@ impl ConjugatePrior<f64, Gaussian> for NormalInvChiSquared {
         GaussianSuffStat::new()
     }
 
-    fn posterior(&self, x: &DataOrSuffStat<f64, Gaussian>) -> Self {
-        extract_stat_then(self, x, |stat: &GaussianSuffStat| {
-            posterior_from_stat(self, &stat).into()
-        })
+    fn posterior_from_suffstat(
+        &self,
+        stat: &GaussianSuffStat,
+    ) -> Self::Posterior {
+        posterior_from_stat(self, stat).into()
     }
 
     #[inline]

--- a/src/dist/scaled_prior.rs
+++ b/src/dist/scaled_prior.rs
@@ -220,7 +220,7 @@ where
 mod tests {
     use super::*;
     use crate::data::DataOrSuffStat;
-    use crate::dist::{NormalInvChiSquared};
+    use crate::dist::NormalInvChiSquared;
     use rand::SeedableRng;
     use rand_xoshiro::Xoshiro256Plus;
 

--- a/src/dist/scaled_prior.rs
+++ b/src/dist/scaled_prior.rs
@@ -171,7 +171,7 @@ where
         stat: &ScaledSuffStat<Fx::Stat>,
     ) -> Self::Posterior {
         ScaledPrior::new_unchecked(
-            self.parent.posterior_from_suffstat(&stat.parent()),
+            self.parent.posterior_from_suffstat(stat.parent()),
             self.scale,
         )
     }

--- a/src/dist/scaled_prior.rs
+++ b/src/dist/scaled_prior.rs
@@ -166,16 +166,14 @@ where
         ScaledSuffStat::new(parent_stat, self.scale)
     }
 
-    fn posterior(
+    fn posterior_from_suffstat(
         &self,
-        x: &DataOrSuffStat<f64, Scaled<Fx>>,
+        stat: &ScaledSuffStat<Fx::Stat>,
     ) -> Self::Posterior {
-        extract_stat_then(self, x, |stat: &ScaledSuffStat<Fx::Stat>| {
-            ScaledPrior::new_unchecked(
-                self.parent.posterior_from_suffstat(&stat.parent()),
-                self.scale,
-            )
-        })
+        ScaledPrior::new_unchecked(
+            self.parent.posterior_from_suffstat(&stat.parent()),
+            self.scale,
+        )
     }
 
     fn ln_m_cache(&self) -> Self::MCache {

--- a/src/dist/scaled_prior.rs
+++ b/src/dist/scaled_prior.rs
@@ -1,0 +1,303 @@
+use crate::dist::Scaled;
+use crate::traits::*;
+use rand::Rng;
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::marker::PhantomData;
+use crate::data::{DataOrSuffStat, ScaledSuffStat};
+
+/// A wrapper for priors that scales the output distribution
+/// 
+/// If drawing a `Pr` gives a distribution `Fx`, then drawing `ScaledPrior<Pr>` 
+/// will produce a `Scaled<Fx>`.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", serde(rename_all = "snake_case"))]
+pub struct ScaledPrior<Pr, Fx>
+where
+    Pr: Sampleable<Fx>,
+    Fx: Scalable,
+{
+    parent: Pr,
+    scale: f64,
+    rate: f64,
+    logjac: f64,
+    _phantom: PhantomData<Fx>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ScaledPriorError {
+    /// The scale parameter must be a normal (finite, non-zero, non-subnormal) number
+    NonNormalScale(f64),
+    /// The scale parameter must be positive
+    NegativeScale(f64),
+}
+
+impl std::error::Error for ScaledPriorError {}
+
+impl fmt::Display for ScaledPriorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonNormalScale(scale) => {
+                write!(f, "non-normal scale: {}", scale)
+            }
+            Self::NegativeScale(scale) => {
+                write!(f, "negative scale: {}", scale)
+            }
+        }
+    }
+}
+
+impl<Pr, Fx> ScaledPrior<Pr, Fx>
+where
+    Pr: Sampleable<Fx>,
+    Fx: Scalable,
+{
+    /// Creates a new scaled prior with the given parent prior and scale factor.
+    ///
+    /// # Errors
+    /// Returns `ScaledPriorError::NonNormalScale` if the scale parameter is not a
+    /// normal number (i.e., if it's zero, infinite, or NaN).
+    ///
+    /// Returns `ScaledPriorError::NegativeScale` if the scale parameter is not positive.
+    pub fn new(parent: Pr, scale: f64) -> Result<Self, ScaledPriorError> {
+        if !scale.is_normal() {
+            Err(ScaledPriorError::NonNormalScale(scale))
+        } else if scale <= 0.0 {
+            Err(ScaledPriorError::NegativeScale(scale))
+        } else {
+            Ok(ScaledPrior {
+                parent,
+                scale,
+                rate: scale.recip(),
+                logjac: scale.abs().ln(),
+                _phantom: PhantomData,
+            })
+        }
+    }
+
+    /// Creates a new scaled prior with the given parent prior and scale factor,
+    /// without checking the scale parameter.
+    ///
+    /// # Safety
+    /// The scale parameter must be a positive normal (finite, non-zero,
+    /// non-subnormal) number.
+    pub fn new_unchecked(parent: Pr, scale: f64) -> Self {
+        ScaledPrior {
+            parent,
+            scale,
+            rate: scale.recip(),
+            logjac: scale.abs().ln(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn parent(&self) -> &Pr {
+        &self.parent
+    }
+
+    pub fn parent_mut(&mut self) -> &mut Pr {
+        &mut self.parent
+    }
+
+    pub fn scale(&self) -> f64 {
+        self.scale
+    }
+
+    pub fn rate(&self) -> f64 {
+        self.rate
+    }
+
+    pub fn logjac(&self) -> f64 {
+        self.logjac
+    }
+}
+
+impl<Pr, Fx> Sampleable<Scaled<Fx>> for ScaledPrior<Pr, Fx>
+where
+    Pr: Sampleable<Fx>,
+    Fx: Scalable,
+{
+    fn draw<R: Rng>(&self, rng: &mut R) -> Scaled<Fx> {
+        let fx = self.parent.draw(rng);
+        Scaled::new_unchecked(fx, self.scale)
+    }
+}
+
+pub struct ScaledPriorParameters<Pr: Parameterized> {
+    parent: Pr::Parameters,
+    scale: f64,
+}
+
+impl<Pr, Fx> Parameterized for ScaledPrior<Pr, Fx>
+where
+    Pr: Sampleable<Fx> + Parameterized,
+    Fx: Scalable,
+{
+    type Parameters = ScaledPriorParameters<Pr>;
+
+    fn emit_params(&self) -> Self::Parameters {
+        ScaledPriorParameters {
+            parent: self.parent.emit_params(),
+            scale: self.scale,
+        }
+    }
+
+    fn from_params(params: Self::Parameters) -> Self {
+        let parent = Pr::from_params(params.parent);
+        Self::new_unchecked(parent, params.scale)
+    }
+}
+
+/// Helper trait to convert between scaled and unscaled data
+/// 
+/// This is used internally by the ConjugatePrior implementation for ScaledPrior.
+trait ScaleData<X> {
+    /// Scale the data by the given factor
+    fn scale_data(&self, scale: f64) -> Self;
+}
+
+impl<X: std::ops::Mul<f64, Output = X> + Clone> ScaleData<X> for X {
+    fn scale_data(&self, scale: f64) -> Self {
+        self.clone() * scale
+    }
+}
+
+impl<X: std::ops::Mul<f64, Output = X> + Clone> ScaleData<X> for Vec<X> {
+    fn scale_data(&self, scale: f64) -> Self {
+        self.iter().map(|x| x.clone() * scale).collect()
+    }
+}
+
+impl<X: std::ops::Mul<f64, Output = X> + Clone> ScaleData<X> for &[X] {
+    fn scale_data(&self, scale: f64) -> Self {
+        &self.iter().map(|x| x.clone() * scale).collect::<Vec<_>>()[..]
+    }
+}
+
+impl<Pr, X, Fx> ConjugatePrior<X, Scaled<Fx>> for ScaledPrior<Pr, Fx>
+where
+    Pr: ConjugatePrior<X, Fx>,
+    Fx: HasDensity<X> + HasSuffStat<X> + Scalable,
+    X: std::ops::Mul<f64, Output = X> + Clone,
+{
+    type Posterior = ScaledPrior<Pr::Posterior, Fx>;
+    type MCache = Pr::MCache;
+    type PpCache = (Pr::PpCache, f64); // Parent cache and scale
+
+    fn empty_stat(&self) -> <Scaled<Fx> as HasSuffStat<X>>::Stat {
+        // For a Scaled<Fx>, the Stat is ScaledSuffStat<Fx::Stat>
+        ScaledSuffStat::new(self.parent.empty_stat(), self.scale)
+    }
+
+    fn posterior(&self, x: &DataOrSuffStat<X, Scaled<Fx>>) -> Self::Posterior {
+        // We need to convert the data for Scaled<Fx> into data for Fx
+        // This means scaling by rate = 1/scale
+        let parent_data = match x {
+            DataOrSuffStat::Data(data) => {
+                // Scale the data by rate
+                let scaled_data = data.scale_data(self.rate);
+                DataOrSuffStat::Data(&scaled_data)
+            }
+            DataOrSuffStat::SuffStat(stat) => {
+                // The stat is already set up to handle the scaling
+                // Just access the parent stat directly
+                DataOrSuffStat::SuffStat(stat.parent())
+            }
+        };
+        
+        // Get posterior from parent
+        let parent_posterior = self.parent.posterior(&parent_data);
+        
+        // Wrap in ScaledPrior with the same scale
+        ScaledPrior::new_unchecked(parent_posterior, self.scale)
+    }
+
+    fn ln_m_cache(&self) -> Self::MCache {
+        self.parent.ln_m_cache()
+    }
+
+    fn ln_m_with_cache(
+        &self,
+        cache: &Self::MCache,
+        x: &DataOrSuffStat<X, Scaled<Fx>>,
+    ) -> f64 {
+        // We need to convert the data for Scaled<Fx> into data for Fx
+        let parent_data = match x {
+            DataOrSuffStat::Data(data) => {
+                // Scale the data by rate
+                let scaled_data = data.scale_data(self.rate);
+                DataOrSuffStat::Data(&scaled_data)
+            }
+            DataOrSuffStat::SuffStat(stat) => {
+                // The stat is already set up to handle the scaling
+                // Just access the parent stat directly
+                DataOrSuffStat::SuffStat(stat.parent())
+            }
+        };
+        
+        // Use parent's ln_m_with_cache
+        self.parent.ln_m_with_cache(cache, &parent_data)
+    }
+
+    fn ln_pp_cache(&self, x: &DataOrSuffStat<X, Scaled<Fx>>) -> Self::PpCache {
+        // We need to convert the data for Scaled<Fx> into data for Fx
+        let parent_data = match x {
+            DataOrSuffStat::Data(data) => {
+                // Scale the data by rate
+                let scaled_data = data.scale_data(self.rate);
+                DataOrSuffStat::Data(&scaled_data)
+            }
+            DataOrSuffStat::SuffStat(stat) => {
+                // The stat is already set up to handle the scaling
+                // Just access the parent stat directly
+                DataOrSuffStat::SuffStat(stat.parent())
+            }
+        };
+        
+        // Get cache from parent and save our scale
+        (self.parent.ln_pp_cache(&parent_data), self.scale)
+    }
+
+    fn ln_pp_with_cache(&self, cache: &Self::PpCache, y: &X) -> f64 {
+        // Unpack the cache
+        let (parent_cache, scale) = cache;
+        
+        // Scale y by rate to get into parent's space
+        let scaled_y = y.clone() * self.rate;
+        
+        // Use parent's ln_pp_with_cache
+        self.parent.ln_pp_with_cache(parent_cache, &scaled_y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dist::{Gaussian, NormalInvChiSquared};
+    use rand::SeedableRng;
+    use rand_xoshiro::Xoshiro256Plus;
+
+    #[test]
+    fn test_scaled_prior_draw() {
+        let prior = NormalInvChiSquared::new_unchecked(0.0, 1.0, 2.0, 1.0);
+        let scaled_prior = ScaledPrior::new(prior, 2.0).unwrap();
+        
+        let mut rng = Xoshiro256Plus::seed_from_u64(42);
+        let dist = scaled_prior.draw(&mut rng);
+        
+        assert_eq!(dist.scale(), 2.0);
+    }
+    
+    #[test]
+    fn test_scale_data() {
+        let x = 2.0;
+        let scaled = x.scale_data(3.0);
+        assert_eq!(scaled, 6.0);
+        
+        let vec = vec![1.0, 2.0, 3.0];
+        let scaled_vec = vec.scale_data(2.0);
+        assert_eq!(scaled_vec, vec![2.0, 4.0, 6.0]);
+    }
+} 

--- a/src/dist/scaled_prior.rs
+++ b/src/dist/scaled_prior.rs
@@ -1,4 +1,3 @@
-use crate::data::extract_stat_then;
 use crate::data::{DataOrSuffStat, ScaledSuffStat};
 use crate::dist::Scaled;
 use crate::traits::*;

--- a/src/dist/scaled_prior.rs
+++ b/src/dist/scaled_prior.rs
@@ -156,7 +156,7 @@ where
     Fx: HasSuffStat<f64> + Scalable + HasDensity<f64>,
     Scaled<Fx>: HasSuffStat<f64, Stat = ScaledSuffStat<Fx::Stat>>,
 {
-    type Posterior = Self;
+    type Posterior = ScaledPrior<Pr::Posterior, Fx>;
     type MCache = Pr::MCache;
     type PpCache = Pr::PpCache;
 

--- a/src/dist/shifted.rs
+++ b/src/dist/shifted.rs
@@ -42,6 +42,10 @@ impl<D> Shifted<D> {
     pub fn new_unchecked(parent: D, shift: f64) -> Self {
         Shifted { parent, shift }
     }
+
+    pub fn shift(&self) -> f64 {
+        self.shift
+    }
 }
 
 impl<D> Sampleable<f64> for Shifted<D>

--- a/src/dist/shifted_prior.rs
+++ b/src/dist/shifted_prior.rs
@@ -1,3 +1,4 @@
+use crate::data::{DataOrSuffStat, ShiftedSuffStat};
 use crate::dist::Shifted;
 use crate::traits::*;
 use rand::Rng;
@@ -5,11 +6,10 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::marker::PhantomData;
-use crate::data::{DataOrSuffStat, ShiftedSuffStat};
 
 /// A wrapper for priors that shifts the output distribution
-/// 
-/// If drawing a `Pr` gives a distribution `Fx`, then drawing `ShiftedPrior<Pr>` 
+///
+/// If drawing a `Pr` gives a distribution `Fx`, then drawing `ShiftedPrior<Pr>`
 /// will produce a `Shifted<Fx>`.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
@@ -141,15 +141,21 @@ where
         ShiftedSuffStat::new(parent_stat, self.shift)
     }
 
-    fn posterior(&self, x: &DataOrSuffStat<f64, Shifted<Fx>>) -> Self::Posterior {
+    fn posterior(
+        &self,
+        x: &DataOrSuffStat<f64, Shifted<Fx>>,
+    ) -> Self::Posterior {
         // For now, we'll just compute a new posterior with the same parameters
         // In the future, we should implement proper handling of the data
         let data: Vec<f64> = match x {
-            DataOrSuffStat::Data(xs) => xs.iter().map(|&x| x - self.shift).collect(),
+            DataOrSuffStat::Data(xs) => {
+                xs.iter().map(|&x| x - self.shift).collect()
+            }
             DataOrSuffStat::SuffStat(_) => vec![], // Not handling suffstat for now
         };
-        
-        let posterior_parent = self.parent.posterior(&DataOrSuffStat::Data(&data));
+
+        let posterior_parent =
+            self.parent.posterior(&DataOrSuffStat::Data(&data));
         Self::new_unchecked(posterior_parent, self.shift)
     }
 
@@ -164,20 +170,28 @@ where
     ) -> f64 {
         // For now, we'll just compute from data
         let data: Vec<f64> = match x {
-            DataOrSuffStat::Data(xs) => xs.iter().map(|&x| x - self.shift).collect(),
+            DataOrSuffStat::Data(xs) => {
+                xs.iter().map(|&x| x - self.shift).collect()
+            }
             DataOrSuffStat::SuffStat(_) => vec![], // Not handling suffstat for now
         };
-        
-        self.parent.ln_m_with_cache(cache, &DataOrSuffStat::Data(&data))
+
+        self.parent
+            .ln_m_with_cache(cache, &DataOrSuffStat::Data(&data))
     }
 
-    fn ln_pp_cache(&self, x: &DataOrSuffStat<f64, Shifted<Fx>>) -> Self::PpCache {
+    fn ln_pp_cache(
+        &self,
+        x: &DataOrSuffStat<f64, Shifted<Fx>>,
+    ) -> Self::PpCache {
         // For now, we'll just compute from data
         let data: Vec<f64> = match x {
-            DataOrSuffStat::Data(xs) => xs.iter().map(|&x| x - self.shift).collect(),
+            DataOrSuffStat::Data(xs) => {
+                xs.iter().map(|&x| x - self.shift).collect()
+            }
             DataOrSuffStat::SuffStat(_) => vec![], // Not handling suffstat for now
         };
-        
+
         self.parent.ln_pp_cache(&DataOrSuffStat::Data(&data))
     }
 
@@ -202,10 +216,10 @@ mod tests {
     fn test_shifted_prior_draw() {
         let prior = NormalInvChiSquared::new_unchecked(0.0, 1.0, 2.0, 1.0);
         let shifted_prior = ShiftedPrior::new(prior, 2.0).unwrap();
-        
+
         let mut rng = Xoshiro256Plus::seed_from_u64(42);
         let dist = shifted_prior.draw(&mut rng);
-        
+
         assert_eq!(dist.shift(), 2.0);
     }
 
@@ -213,44 +227,44 @@ mod tests {
     fn test_shifted_prior_conjugate() {
         let prior = NormalInvChiSquared::new_unchecked(0.0, 1.0, 2.0, 1.0);
         let shifted_prior = ShiftedPrior::new(prior, 2.0).unwrap();
-        
+
         // Create an empty stat to test
         let stat = shifted_prior.empty_stat();
         assert_eq!(stat.shift(), 2.0);
-        
+
         // Test posterior with empty data
         let data: Vec<f64> = Vec::new();
         // Manually create DataOrSuffStat instead of using .into()
         let dos = DataOrSuffStat::Data(&data);
         let posterior = shifted_prior.posterior(&dos);
-        
+
         // Shift should persist through posterior computation
         assert_eq!(posterior.shift(), 2.0);
     }
-    
+
     #[test]
     fn test_shifted_prior_with_data() {
         let prior = NormalInvChiSquared::new_unchecked(0.0, 1.0, 2.0, 1.0);
         let shifted_prior = ShiftedPrior::new(prior, 2.0).unwrap();
-        
+
         // Create some data - will be shifted by -2.0 internally for parent calculations
         let data = vec![2.0, 4.0, 6.0];
-        
+
         // Manually create DataOrSuffStat instead of using .into()
         let dos = DataOrSuffStat::Data(&data);
-        
+
         // Compute posterior
         let posterior = shifted_prior.posterior(&dos);
-        
+
         // Shift should persist through posterior computation
         assert_eq!(posterior.shift(), 2.0);
-        
+
         // Verify ln_m and ln_pp work
         let ln_m = shifted_prior.ln_m(&dos);
         let ln_pp = shifted_prior.ln_pp(&2.0, &dos);
-        
+
         // Values should be finite (actual values will depend on implementation)
         assert!(ln_m.is_finite());
         assert!(ln_pp.is_finite());
     }
-} 
+}

--- a/src/dist/shifted_prior.rs
+++ b/src/dist/shifted_prior.rs
@@ -147,7 +147,7 @@ where
         stat: &ShiftedSuffStat<Fx::Stat>,
     ) -> Self::Posterior {
         ShiftedPrior::new_unchecked(
-            self.parent.posterior_from_suffstat(&stat.parent()),
+            self.parent.posterior_from_suffstat(stat.parent()),
             self.shift,
         )
     }

--- a/src/dist/shifted_prior.rs
+++ b/src/dist/shifted_prior.rs
@@ -1,5 +1,5 @@
-use crate::data::{DataOrSuffStat, ShiftedSuffStat};
 use crate::data::extract_stat_then;
+use crate::data::{DataOrSuffStat, ShiftedSuffStat};
 use crate::dist::Shifted;
 use crate::traits::*;
 use rand::Rng;
@@ -151,7 +151,7 @@ where
             self.shift,
         )
     }
-    
+
     fn posterior(
         &self,
         x: &DataOrSuffStat<f64, Shifted<Fx>>,
@@ -202,7 +202,7 @@ where
 mod tests {
     use super::*;
     use crate::data::DataOrSuffStat;
-    use crate::dist::{NormalInvChiSquared};
+    use crate::dist::NormalInvChiSquared;
     use rand::SeedableRng;
     use rand_xoshiro::Xoshiro256Plus;
 

--- a/src/dist/shifted_prior.rs
+++ b/src/dist/shifted_prior.rs
@@ -207,8 +207,7 @@ where
 mod tests {
     use super::*;
     use crate::data::DataOrSuffStat;
-    use crate::dist::{Gaussian, NormalInvChiSquared, Shifted};
-    use crate::traits::*;
+    use crate::dist::{NormalInvChiSquared};
     use rand::SeedableRng;
     use rand_xoshiro::Xoshiro256Plus;
 

--- a/src/dist/shifted_prior.rs
+++ b/src/dist/shifted_prior.rs
@@ -1,0 +1,256 @@
+use crate::dist::Shifted;
+use crate::traits::*;
+use rand::Rng;
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::marker::PhantomData;
+use crate::data::{DataOrSuffStat, ShiftedSuffStat};
+
+/// A wrapper for priors that shifts the output distribution
+/// 
+/// If drawing a `Pr` gives a distribution `Fx`, then drawing `ShiftedPrior<Pr>` 
+/// will produce a `Shifted<Fx>`.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", serde(rename_all = "snake_case"))]
+pub struct ShiftedPrior<Pr, Fx>
+where
+    Pr: Sampleable<Fx>,
+    Fx: Shiftable,
+{
+    parent: Pr,
+    shift: f64,
+    _phantom: PhantomData<Fx>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ShiftedPriorError {
+    /// The shift parameter must be a finite number
+    NonFiniteShift(f64),
+}
+
+impl std::error::Error for ShiftedPriorError {}
+
+impl fmt::Display for ShiftedPriorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonFiniteShift(shift) => {
+                write!(f, "non-finite shift: {}", shift)
+            }
+        }
+    }
+}
+
+impl<Pr, Fx> ShiftedPrior<Pr, Fx>
+where
+    Pr: Sampleable<Fx>,
+    Fx: Shiftable,
+{
+    /// Creates a new shifted prior with the given parent prior and shift value.
+    ///
+    /// # Errors
+    /// Returns `ShiftedPriorError::NonFiniteShift` if the shift parameter is not
+    /// a finite number (i.e., if it's infinite or NaN).
+    pub fn new(parent: Pr, shift: f64) -> Result<Self, ShiftedPriorError> {
+        if !shift.is_finite() {
+            Err(ShiftedPriorError::NonFiniteShift(shift))
+        } else {
+            Ok(ShiftedPrior {
+                parent,
+                shift,
+                _phantom: PhantomData,
+            })
+        }
+    }
+
+    /// Creates a new shifted prior with the given parent prior and shift value,
+    /// without checking the shift parameter.
+    ///
+    /// # Safety
+    /// The shift parameter must be a finite number.
+    pub fn new_unchecked(parent: Pr, shift: f64) -> Self {
+        ShiftedPrior {
+            parent,
+            shift,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn parent(&self) -> &Pr {
+        &self.parent
+    }
+
+    pub fn parent_mut(&mut self) -> &mut Pr {
+        &mut self.parent
+    }
+
+    pub fn shift(&self) -> f64 {
+        self.shift
+    }
+}
+
+impl<Pr, Fx> Sampleable<Shifted<Fx>> for ShiftedPrior<Pr, Fx>
+where
+    Pr: Sampleable<Fx>,
+    Fx: Shiftable,
+{
+    fn draw<R: Rng>(&self, rng: &mut R) -> Shifted<Fx> {
+        let fx = self.parent.draw(rng);
+        Shifted::new_unchecked(fx, self.shift)
+    }
+}
+
+pub struct ShiftedPriorParameters<Pr: Parameterized> {
+    parent: Pr::Parameters,
+    shift: f64,
+}
+
+impl<Pr, Fx> Parameterized for ShiftedPrior<Pr, Fx>
+where
+    Pr: Sampleable<Fx> + Parameterized,
+    Fx: Shiftable,
+{
+    type Parameters = ShiftedPriorParameters<Pr>;
+
+    fn emit_params(&self) -> Self::Parameters {
+        ShiftedPriorParameters {
+            parent: self.parent.emit_params(),
+            shift: self.shift,
+        }
+    }
+
+    fn from_params(params: Self::Parameters) -> Self {
+        let parent = Pr::from_params(params.parent);
+        Self::new_unchecked(parent, params.shift)
+    }
+}
+
+impl<Pr, Fx> ConjugatePrior<f64, Shifted<Fx>> for ShiftedPrior<Pr, Fx>
+where
+    Pr: ConjugatePrior<f64, Fx, Posterior = Pr>,
+    Fx: HasSuffStat<f64> + Shiftable + HasDensity<f64>,
+    Shifted<Fx>: HasSuffStat<f64, Stat = ShiftedSuffStat<Fx::Stat>>,
+{
+    type Posterior = Self;
+    type MCache = Pr::MCache;
+    type PpCache = Pr::PpCache;
+
+    fn empty_stat(&self) -> ShiftedSuffStat<Fx::Stat> {
+        let parent_stat = self.parent.empty_stat();
+        ShiftedSuffStat::new(parent_stat, self.shift)
+    }
+
+    fn posterior(&self, x: &DataOrSuffStat<f64, Shifted<Fx>>) -> Self::Posterior {
+        // For now, we'll just compute a new posterior with the same parameters
+        // In the future, we should implement proper handling of the data
+        let data: Vec<f64> = match x {
+            DataOrSuffStat::Data(xs) => xs.iter().map(|&x| x - self.shift).collect(),
+            DataOrSuffStat::SuffStat(_) => vec![], // Not handling suffstat for now
+        };
+        
+        let posterior_parent = self.parent.posterior(&DataOrSuffStat::Data(&data));
+        Self::new_unchecked(posterior_parent, self.shift)
+    }
+
+    fn ln_m_cache(&self) -> Self::MCache {
+        self.parent.ln_m_cache()
+    }
+
+    fn ln_m_with_cache(
+        &self,
+        cache: &Self::MCache,
+        x: &DataOrSuffStat<f64, Shifted<Fx>>,
+    ) -> f64 {
+        // For now, we'll just compute from data
+        let data: Vec<f64> = match x {
+            DataOrSuffStat::Data(xs) => xs.iter().map(|&x| x - self.shift).collect(),
+            DataOrSuffStat::SuffStat(_) => vec![], // Not handling suffstat for now
+        };
+        
+        self.parent.ln_m_with_cache(cache, &DataOrSuffStat::Data(&data))
+    }
+
+    fn ln_pp_cache(&self, x: &DataOrSuffStat<f64, Shifted<Fx>>) -> Self::PpCache {
+        // For now, we'll just compute from data
+        let data: Vec<f64> = match x {
+            DataOrSuffStat::Data(xs) => xs.iter().map(|&x| x - self.shift).collect(),
+            DataOrSuffStat::SuffStat(_) => vec![], // Not handling suffstat for now
+        };
+        
+        self.parent.ln_pp_cache(&DataOrSuffStat::Data(&data))
+    }
+
+    fn ln_pp_with_cache(&self, cache: &Self::PpCache, y: &f64) -> f64 {
+        // Shift y back to the parent distribution's space
+        let shifted_y = *y - self.shift;
+        // Compute the log posterior predictive using the parent
+        self.parent.ln_pp_with_cache(cache, &shifted_y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::DataOrSuffStat;
+    use crate::dist::{Gaussian, NormalInvChiSquared, Shifted};
+    use crate::traits::*;
+    use rand::SeedableRng;
+    use rand_xoshiro::Xoshiro256Plus;
+
+    #[test]
+    fn test_shifted_prior_draw() {
+        let prior = NormalInvChiSquared::new_unchecked(0.0, 1.0, 2.0, 1.0);
+        let shifted_prior = ShiftedPrior::new(prior, 2.0).unwrap();
+        
+        let mut rng = Xoshiro256Plus::seed_from_u64(42);
+        let dist = shifted_prior.draw(&mut rng);
+        
+        assert_eq!(dist.shift(), 2.0);
+    }
+
+    #[test]
+    fn test_shifted_prior_conjugate() {
+        let prior = NormalInvChiSquared::new_unchecked(0.0, 1.0, 2.0, 1.0);
+        let shifted_prior = ShiftedPrior::new(prior, 2.0).unwrap();
+        
+        // Create an empty stat to test
+        let stat = shifted_prior.empty_stat();
+        assert_eq!(stat.shift(), 2.0);
+        
+        // Test posterior with empty data
+        let data: Vec<f64> = Vec::new();
+        // Manually create DataOrSuffStat instead of using .into()
+        let dos = DataOrSuffStat::Data(&data);
+        let posterior = shifted_prior.posterior(&dos);
+        
+        // Shift should persist through posterior computation
+        assert_eq!(posterior.shift(), 2.0);
+    }
+    
+    #[test]
+    fn test_shifted_prior_with_data() {
+        let prior = NormalInvChiSquared::new_unchecked(0.0, 1.0, 2.0, 1.0);
+        let shifted_prior = ShiftedPrior::new(prior, 2.0).unwrap();
+        
+        // Create some data - will be shifted by -2.0 internally for parent calculations
+        let data = vec![2.0, 4.0, 6.0];
+        
+        // Manually create DataOrSuffStat instead of using .into()
+        let dos = DataOrSuffStat::Data(&data);
+        
+        // Compute posterior
+        let posterior = shifted_prior.posterior(&dos);
+        
+        // Shift should persist through posterior computation
+        assert_eq!(posterior.shift(), 2.0);
+        
+        // Verify ln_m and ln_pp work
+        let ln_m = shifted_prior.ln_m(&dos);
+        let ln_pp = shifted_prior.ln_pp(&2.0, &dos);
+        
+        // Values should be finite (actual values will depend on implementation)
+        assert!(ln_m.is_finite());
+        assert!(ln_pp.is_finite());
+    }
+} 

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -641,7 +641,7 @@ mod tests {
 
     #[test]
     fn slice_step_vs_draw_test() {
-        let n_samples = 1000000;
+        let n_samples = 1_000_000;
         let mut rng = rand::thread_rng();
         let mu = 1.5;
         let k = 2.0;

--- a/src/experimental/stick_breaking_process/stick_breaking.rs
+++ b/src/experimental/stick_breaking_process/stick_breaking.rs
@@ -288,22 +288,6 @@ impl ConjugatePrior<usize, StickBreakingDiscrete> for StickBreaking {
         }
     }
 
-    fn posterior(
-        &self,
-        x: &DataOrSuffStat<usize, StickBreakingDiscrete>,
-    ) -> Self::Posterior {
-        match x {
-            DataOrSuffStat::Data(xs) => {
-                let mut stat = StickBreakingDiscreteSuffStat::new();
-                stat.observe_many(xs);
-                self.posterior_from_suffstat(&stat)
-            }
-            DataOrSuffStat::SuffStat(stat) => {
-                self.posterior_from_suffstat(stat)
-            }
-        }
-    }
-
     /// Computes the logarithm of the marginal likelihood.
     fn ln_m(&self, x: &DataOrSuffStat<usize, StickBreakingDiscrete>) -> f64 {
         let count_pairs = match x {

--- a/src/misc/bessel.rs
+++ b/src/misc/bessel.rs
@@ -158,8 +158,11 @@ pub fn log_i0(x: f64) -> f64 {
         let y = ax.mul_add(0.5, -2.0);
         ax + chbevl(y, &BESSI0_COEFFS_A).ln()
     } else {
-        ax + chbevl(32.0_f64.mul_add(ax.recip(), -2.0), &BESSI0_COEFFS_B).ln()
-            - 0.5 * ax.ln()
+        0.5_f64.mul_add(
+            -ax.ln(),
+            ax + chbevl(32.0_f64.mul_add(ax.recip(), -2.0), &BESSI0_COEFFS_B)
+                .ln(),
+        )
     }
 }
 

--- a/src/misc/func.rs
+++ b/src/misc/func.rs
@@ -469,6 +469,7 @@ pub fn sorted_uniforms<R: Rng>(n: usize, rng: &mut R) -> Vec<f64> {
     xs
 }
 
+#[allow(dead_code)]
 pub(crate) fn eq_or_close(a: f64, b: f64, tol: f64) -> bool {
     a == b                                           // Really equal, or both -Inf or Inf
         || a.is_nan() && b.is_nan()                  // Both NaN

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,8 +10,8 @@ macro_rules! test_serde_params {
     ($fx: expr, $fx_ty: ty, $x_ty: ty) => {
         #[test]
         fn test_serde_ln_f() {
-            use ::serde::Deserialize;
-            use ::serde::Serialize;
+            // use ::serde::Deserialize;
+            // use ::serde::Serialize;
             use $crate::traits::HasDensity;
             use $crate::traits::Sampleable;
 
@@ -636,17 +636,17 @@ where
     Ok(p_value)
 }
 
-mod tests {
-    use crate::prelude::Exponential;
-    use crate::prelude::Gaussian;
-    use crate::test::density_histogram_test;
-    use crate::traits::HasDensity;
-    use crate::traits::Sampleable;
-    use rand::SeedableRng;
-    use rand_xoshiro::Xoshiro256Plus;
+mod tests {   
 
     #[test]
     fn test_density_histogram_gaussian() {
+        use crate::prelude::Gaussian;
+        use crate::test::density_histogram_test;   
+        use crate::traits::HasDensity;
+        use crate::traits::Sampleable;
+        use rand_xoshiro::Xoshiro256Plus;
+        use rand::SeedableRng;
+
         let mut rng = Xoshiro256Plus::seed_from_u64(1);
         let dist = Gaussian::default();
 
@@ -670,6 +670,13 @@ mod tests {
 
     #[test]
     fn test_density_histogram_exponential() {
+        use crate::prelude::Exponential;
+        use crate::traits::Sampleable;
+        use crate::traits::HasDensity;
+        use crate::test::density_histogram_test;     
+        use rand_xoshiro::Xoshiro256Plus;
+        use rand::SeedableRng;
+
         let mut rng = Xoshiro256Plus::seed_from_u64(1);
         let dist = Exponential::default();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -581,14 +581,13 @@ where
     let mut total_integral = 0.0;
 
     for bin_ix in 0..num_bins {
-        let bin_start = min_val + bin_ix as f64 * bin_width;
+        let bin_start = (bin_ix as f64).mul_add(bin_width, min_val);
         let bin_mid = bin_start + bin_width / 2.0;
         let bin_end = bin_start + bin_width;
 
         // Apply Simpson's rule for each bin
         let integral = (bin_width / 6.0)
-            * (density_fn(bin_start)
-                + 4.0 * density_fn(bin_mid)
+            * (4.0_f64.mul_add(density_fn(bin_mid), density_fn(bin_start))
                 + density_fn(bin_end));
 
         expected_counts.push(integral);

--- a/src/test.rs
+++ b/src/test.rs
@@ -636,16 +636,16 @@ where
     Ok(p_value)
 }
 
-mod tests {   
+mod tests {
 
     #[test]
     fn test_density_histogram_gaussian() {
         use crate::prelude::Gaussian;
-        use crate::test::density_histogram_test;   
+        use crate::test::density_histogram_test;
         use crate::traits::HasDensity;
         use crate::traits::Sampleable;
-        use rand_xoshiro::Xoshiro256Plus;
         use rand::SeedableRng;
+        use rand_xoshiro::Xoshiro256Plus;
 
         let mut rng = Xoshiro256Plus::seed_from_u64(1);
         let dist = Gaussian::default();
@@ -671,11 +671,11 @@ mod tests {
     #[test]
     fn test_density_histogram_exponential() {
         use crate::prelude::Exponential;
-        use crate::traits::Sampleable;
+        use crate::test::density_histogram_test;
         use crate::traits::HasDensity;
-        use crate::test::density_histogram_test;     
-        use rand_xoshiro::Xoshiro256Plus;
+        use crate::traits::Sampleable;
         use rand::SeedableRng;
+        use rand_xoshiro::Xoshiro256Plus;
 
         let mut rng = Xoshiro256Plus::seed_from_u64(1);
         let dist = Exponential::default();

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,8 +10,6 @@ macro_rules! test_serde_params {
     ($fx: expr, $fx_ty: ty, $x_ty: ty) => {
         #[test]
         fn test_serde_ln_f() {
-            // use ::serde::Deserialize;
-            // use ::serde::Serialize;
             use $crate::traits::HasDensity;
             use $crate::traits::Sampleable;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,5 @@
 //! Trait definitions
+use crate::data::extract_stat_then;
 pub use crate::data::DataOrSuffStat;
 use rand::Rng;
 
@@ -558,7 +559,9 @@ where
         self.posterior(&DataOrSuffStat::SuffStat(stat))
     }
 
-    fn posterior(&self, x: &DataOrSuffStat<X, Fx>) -> Self::Posterior;
+    fn posterior(&self, x: &DataOrSuffStat<X, Fx>) -> Self::Posterior {
+        extract_stat_then(self, x, |stat| self.posterior_from_suffstat(stat))
+    }
 
     /// Compute the cache for the log marginal likelihood.
     fn ln_m_cache(&self) -> Self::MCache;


### PR DESCRIPTION
This PR introduces two new prior wrapper types to the distribution module:

- `ScaledPrior<Pr, Fx>`: A wrapper for priors that scales the output distribution. If drawing a `Pr` gives a distribution `Fx`, then drawing `ScaledPrior<Pr>` will produce a `Scaled<Fx>`.

- `ShiftedPrior<Pr, Fx>`: A wrapper for priors that shifts the output distribution. If drawing a `Pr` gives a distribution `Fx`, then drawing `ShiftedPrior<Pr>` will produce a `Shifted<Fx>`.
