### PR TITLE
CDVM update

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -535,7 +535,7 @@ mod tests {
         struct MockPosterior(Gaussian);
 
         impl Sampleable<Gaussian> for MockPosterior {
-            fn draw<R: Rng>(&self, rng: &mut R) -> Gaussian {
+            fn draw<R: Rng>(&self, _rng: &mut R) -> Gaussian {
                 self.0.clone()
             }
         }

--- a/src/data/stat/cdvm.rs
+++ b/src/data/stat/cdvm.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
+use super::ScaledSuffStat;
+use super::VonMisesSuffStat;
 use crate::traits::SuffStat;
 
 /// Cdvm sufficient statistic.
@@ -90,6 +92,17 @@ impl CdvmSuffStat {
     #[inline]
     pub fn sum_sin(&self) -> f64 {
         self.sum_sin
+    }
+}
+
+impl From<CdvmSuffStat> for ScaledSuffStat<VonMisesSuffStat> {
+    fn from(stat: CdvmSuffStat) -> Self {
+        let vonmises_stat = VonMisesSuffStat::from_parts_unchecked(
+            stat.n,
+            stat.sum_sin,
+            stat.sum_cos,
+        );
+        ScaledSuffStat::new(vonmises_stat, stat.twopi_over_m)
     }
 }
 

--- a/src/data/stat/cdvm.rs
+++ b/src/data/stat/cdvm.rs
@@ -25,6 +25,8 @@ pub struct CdvmSuffStat {
     twopi_over_m: f64,
 }
 
+const TWOPI: f64 = 2.0 * std::f64::consts::PI;
+
 impl CdvmSuffStat {
     #[inline]
     pub fn new(modulus: usize) -> Self {
@@ -33,7 +35,7 @@ impl CdvmSuffStat {
             n: 0,
             sum_sin: 0.0,
             sum_cos: 0.0,
-            twopi_over_m: 2.0 * std::f64::consts::PI / modulus as f64,
+            twopi_over_m: TWOPI / modulus as f64,
         }
     }
 
@@ -51,7 +53,7 @@ impl CdvmSuffStat {
             n,
             sum_sin,
             sum_cos,
-            twopi_over_m: 2.0 * std::f64::consts::PI / modulus as f64,
+            twopi_over_m: TWOPI / modulus as f64,
         }
     }
 

--- a/src/data/stat/scaled.rs
+++ b/src/data/stat/scaled.rs
@@ -9,8 +9,6 @@ use serde::{Deserialize, Serialize};
 pub struct ScaledSuffStat<S> {
     parent: S,
     scale: f64,
-
-    #[cfg_attr(feature = "serde1", serde(skip))]
     rate: f64,
 }
 
@@ -21,6 +19,14 @@ impl<S> ScaledSuffStat<S> {
             parent,
             scale,
             rate: scale.recip(),
+        }
+    }
+
+    pub fn from_parts_unchecked(parent: S, scale: f64, rate: f64) -> Self {
+        ScaledSuffStat {
+            parent,
+            scale,
+            rate,
         }
     }
 

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -314,7 +314,7 @@ impl HasSuffStat<usize> for Cdvm {
         // Instead of computing individual probabilities, use the sufficient statistics
         // This is the same formula as the original implementation but with our parameters
         let n = stat.n() as f64;
-        k * (stat.sum_cos() * vm_mu.cos() + stat.sum_sin() * vm_mu.sin()) - n * self.log_norm_const()
+        k.mul_add(stat.sum_cos().mul_add(vm_mu.cos(), stat.sum_sin() * vm_mu.sin()), -(n * self.log_norm_const()))
     }
 }
 

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -41,6 +41,8 @@ use std::sync::OnceLock;
 ///
 /// Note that in while the paper uses μ ∈ [0, 2π), we use μ ∈ [0, m)
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", serde(rename_all = "snake_case"))]
 pub struct Cdvm {
     /// Number of categories
     modulus: usize,

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -49,6 +49,7 @@ pub struct Cdvm {
     parent: Scaled<VonMises>,
 
     /// Cached log-normalization constant
+    #[cfg_attr(feature = "serde1", serde(skip))]
     log_norm_const: OnceLock<f64>,
 }
 

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -287,7 +287,7 @@ impl Support<usize> for Cdvm {
 
 impl Sampleable<usize> for Cdvm {
     fn draw<R: Rng>(&self, rng: &mut R) -> usize {
-        ln_pflip((0..self.modulus).map(|r| self.cdvm_kernel(r)), true, rng)
+        ln_pflip((0..self.modulus).map(|r| self.cdvm_kernel(r)), false, rng)
     }
 }
 

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -33,6 +33,12 @@ pub struct Cdvm {
     log_norm_const: OnceLock<f64>,
 }
 
+impl From<Cdvm> for Scaled<VonMises> {
+    fn from(cdvm: Cdvm) -> Self {
+        cdvm.parent
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct CdvmParameters {
     pub modulus: usize,

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -164,6 +164,10 @@ impl Cdvm {
         &self.parent
     }
 
+    pub fn parent_mut(&mut self) -> &mut Scaled<VonMises> {
+        &mut self.parent
+    }
+
     /// Compute or fetch cached normalization constant
     fn log_norm_const(&self) -> f64 {
         *self.log_norm_const.get_or_init(|| {
@@ -233,7 +237,7 @@ impl Mean<f64> for Cdvm {
 
 impl Mode<usize> for Cdvm {
     fn mode(&self) -> Option<usize> {
-        Some(self.mu().round() as usize % self.modulus)
+        Some(self.mu().round() as usize)
     }
 }
 
@@ -348,11 +352,11 @@ mod tests {
             kappa in 0.1..50.0_f64,
             x in 0..100_usize
         ) {
-            let mu = mu % (m as f64);
+            let mu = mu.rem_euclid(m as f64);
             let cdvm1 = Cdvm::new(mu, kappa, m).unwrap();
             let cdvm2 = Cdvm::new((m as f64) - mu, kappa, m).unwrap();
 
-            let x1 = x % m;
+            let x1 = x.rem_euclid(m);
             let x2 = m - x1;
 
             let lnf1 = cdvm1.ln_f(&x1);
@@ -386,8 +390,8 @@ mod tests {
             kappa in 0.1..50.0_f64,
             x in 0..100_usize,
         ) {
-            let mu = mu % (m as f64);
-            let x = x % m;
+            let mu = mu.rem_euclid(m as f64);
+            let x = x.rem_euclid(m);
             let cdvm = Cdvm::new(mu, kappa, m).unwrap();
             prop_assert!((cdvm.ln_f(&x) - cdvm.ln_f(&(x + m))).abs() < TOL,
                 "ln_f not invariant to wrap-around for m={}, mu={}, kappa={}, x={}", m, mu, kappa, x);
@@ -411,8 +415,8 @@ mod tests {
             kappa in 0.1..50.0_f64,
             xs in prop::collection::vec(0..100_usize, 1..20),
         ) {
-            let mu = mu % (m as f64);
-            let xs: Vec<usize> = xs.into_iter().map(|x| x % m).collect();
+            let mu = mu.rem_euclid(m as f64);
+            let xs: Vec<usize> = xs.into_iter().map(|x| x.rem_euclid(m)).collect();
             let cdvm = Cdvm::new(mu, kappa, m).unwrap();
 
             // Calculate ln_f for each x and sum them

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -90,6 +90,8 @@ impl From<ScaledError> for CdvmError {
     }
 }
 
+const TWOPI: f64 = 2.0 * std::f64::consts::PI;
+
 impl Cdvm {
     /// Create a new CDVM distribution
     ///
@@ -116,7 +118,7 @@ impl Cdvm {
     /// Creates a new CDVM without checking whether the parameters are valid.
     #[inline]
     pub fn new_unchecked(mu: f64, kappa: f64, modulus: usize) -> Self {
-        let scale = modulus as f64 / (2.0 * std::f64::consts::PI);
+        let scale = modulus as f64 / TWOPI;
         let rate = scale.recip();
         let logjac = scale.abs().ln();
         let vm = VonMises::new_unchecked(mu * rate, kappa);

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -14,28 +14,6 @@ use std::f64;
 use std::fmt;
 use std::sync::OnceLock;
 
-// TODO: This can be *much* more efficient if we replace the modulus with
-// something like this. In particular, the suffstat would only need quick
-// lookups and additions, with no trig functions
-//
-// #[derive(Debug, Clone,
-//     PartialEq)] pub struct CdvmModulus { m: usize, twopi_over_m: f64, sines:
-//     Vec<f64>, cosines: Vec<f64>, }
-
-// impl CdvmModulus {
-//     fn new(m: usize) -> Self {
-//         let twopi_over_m = 2.0 * std::f64::consts::PI / m as f64;
-//         let sines = (0..m).map(|x| (twopi_over_m * (x as f64)).sin()).collect();
-//         let cosines = (0..m).map(|x| (twopi_over_m * (x as f64)).cos()).collect();
-//         Self {
-//             m,
-//             twopi_over_m,
-//             sines,
-//             cosines,
-//         }
-//     }
-// }
-
 /// [CDVM distribution](https://arxiv.org/pdf/2009.05437),
 /// A unimodal distribution over x in (0, m-1) where m is the number of categories.
 ///

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -121,7 +121,7 @@ impl Cdvm {
         let logjac = scale.abs().ln();
         let vm = VonMises::new_unchecked(mu * rate, kappa);
         let parent = Scaled::from_parts_unchecked(vm, scale, rate, logjac);
-        
+
         Cdvm {
             modulus,
             parent,
@@ -130,7 +130,10 @@ impl Cdvm {
     }
 
     #[must_use]
-    pub fn from_parts_unchecked(modulus: usize, parent: Scaled<VonMises>) -> Self {
+    pub fn from_parts_unchecked(
+        modulus: usize,
+        parent: Scaled<VonMises>,
+    ) -> Self {
         Self {
             modulus,
             parent,
@@ -138,9 +141,9 @@ impl Cdvm {
         }
     }
 
-
     pub fn cdvm_kernel(&self, x: usize) -> f64 {
-        self.concentration() * ((self.two_pi_over_modulus() * (x as f64 - self.mu())).cos())
+        self.concentration()
+            * ((self.two_pi_over_modulus() * (x as f64 - self.mu())).cos())
     }
 
     /// Get the number of categories
@@ -155,8 +158,6 @@ impl Cdvm {
     pub fn two_pi_over_modulus(&self) -> f64 {
         self.parent().rate()
     }
-
-
 
     /// Get the von Mises mean direction
     pub fn mu(&self) -> f64 {
@@ -199,7 +200,6 @@ impl Cdvm {
 
         Ok(Cdvm::new_unchecked(0.0, 0.0, modulus))
     }
-
 }
 
 impl Parameterized for Cdvm {
@@ -230,7 +230,9 @@ impl From<&Cdvm> for String {
     fn from(cdvm: &Cdvm) -> String {
         format!(
             "CDVM(modulus: {}, μ: {}, κ: {})",
-            cdvm.modulus, cdvm.mu(), cdvm.kappa()
+            cdvm.modulus,
+            cdvm.mu(),
+            cdvm.kappa()
         )
     }
 }
@@ -274,7 +276,7 @@ impl HasDensity<usize> for Cdvm {
     fn ln_f(&self, x: &usize) -> f64 {
         // For Cdvm, we need to support the correct modulo arithmetic
         let x_mod = *x % self.modulus;
-        
+
         // Use the density of the underlying scaled von Mises but adjust for normalization
         self.parent.ln_f(&(x_mod as f64)) - self.log_norm_const()
     }
@@ -306,15 +308,19 @@ impl HasSuffStat<usize> for Cdvm {
         if stat.n() == 0 {
             return 0.0;
         }
-        
+
         // The original implementation used the von Mises kernel directly
         let k = self.kappa();
         let vm_mu = self.parent.parent().mu();
-        
+
         // Instead of computing individual probabilities, use the sufficient statistics
         // This is the same formula as the original implementation but with our parameters
         let n = stat.n() as f64;
-        k.mul_add(stat.sum_cos().mul_add(vm_mu.cos(), stat.sum_sin() * vm_mu.sin()), -(n * self.log_norm_const()))
+        k.mul_add(
+            stat.sum_cos()
+                .mul_add(vm_mu.cos(), stat.sum_sin() * vm_mu.sin()),
+            -(n * self.log_norm_const()),
+        )
     }
 }
 

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -106,6 +106,8 @@ pub enum VonMisesError {
     KNotFinite { k: f64 },
 }
 
+const TWOPI: f64 = 2.0 * std::f64::consts::PI;
+
 impl VonMises {
     /// Create a new VonMises distribution with mean mu, and precision, k.
     pub fn new(mu: f64, k: f64) -> Result<Self, VonMisesError> {
@@ -116,7 +118,7 @@ impl VonMises {
         } else if !k.is_finite() {
             Err(VonMisesError::KNotFinite { k })
         } else {
-            let mu = mu.rem_euclid(2.0 * PI);
+            let mu = mu.rem_euclid(TWOPI);
             let (sin_mu, cos_mu) = mu.sin_cos();
             let log_i0_k = bessel::log_i0(k);
             Ok(VonMises {
@@ -219,7 +221,7 @@ impl VonMises {
         if !mu.is_finite() {
             Err(VonMisesError::MuNotFinite { mu })
         } else {
-            self.set_mu_unchecked(mu.rem_euclid(2.0 * PI));
+            self.set_mu_unchecked(mu.rem_euclid(TWOPI));
             Ok(())
         }
     }
@@ -320,7 +322,7 @@ impl VonMises {
         // Sample uniformly on [-xmax, xmax] and add μ
         let x = xmax.mul_add(rng.gen_range(-1.0..=1.0), mu);
         // Ensure result is in [0, 2π)
-        x.rem_euclid(2.0 * PI)
+        x.rem_euclid(TWOPI)
     }
 }
 
@@ -354,10 +356,10 @@ macro_rules! impl_traits {
             // https://www.researchgate.net/publication/246035131_Efficient_Simulation_of_the_von_Mises_Distribution
             fn draw<R: Rng>(&self, rng: &mut R) -> $kind {
                 if self.k.is_zero() {
-                    rng.gen_range(0.0..=2.0 * PI) as $kind
+                    rng.gen_range(0.0..=TWOPI) as $kind
                 } else if self.k > 700.0 {
                     let normal = Normal::new(self.mu, 1.0 / self.k).unwrap();
-                    rng.sample(normal).rem_euclid(2.0 * PI) as $kind
+                    rng.sample(normal).rem_euclid(TWOPI) as $kind
                 } else {
                     let tau =
                         1.0 + 4.0_f64.mul_add(self.k * self.k, 1.0).sqrt();
@@ -393,7 +395,7 @@ macro_rules! impl_traits {
                     } else {
                         self.mu - acf
                     };
-                    x.rem_euclid(2.0 * PI) as $kind
+                    x.rem_euclid(TWOPI) as $kind
                 }
             }
         }
@@ -422,7 +424,7 @@ macro_rules! impl_traits {
         impl Support<$kind> for VonMises {
             fn supports(&self, x: &$kind) -> bool {
                 let xf = f64::from(*x);
-                (0.0..=2.0 * PI).contains(&xf)
+                (0.0..=TWOPI).contains(&xf)
             }
         }
 
@@ -516,7 +518,7 @@ mod tests {
     fn new_should_allow_mu_in_0_2pi() {
         assert!(VonMises::new(0.0, 1.0).is_ok());
         assert!(VonMises::new(PI, 1.0).is_ok());
-        assert!(VonMises::new(2.0 * PI, 1.0).is_ok());
+        assert!(VonMises::new(TWOPI, 1.0).is_ok());
     }
 
     #[test]
@@ -736,7 +738,7 @@ mod tests {
             let sample: f64 = vm.draw(&mut rng);
 
             prop_assert!(
-                (0.0..2.0 * std::f64::consts::PI).contains(&sample),
+                (0.0..TWOPI).contains(&sample),
                 "Sample {} not in range [0, 2π) for VonMises({}, {})",
                 sample, mu, k
             );


### PR DESCRIPTION
Change `Cdvm` implemented from
```rust
pub struct Cdvm {
    /// Number of categories
    modulus: usize,

    /// mean direction (μ)
    mu: f64,

    /// concentration parameter (κ)
    kappa: f64,

    /// Cached log-normalization constant
    #[cfg_attr(feature = "serde1", serde(skip))]
    log_norm_const: OnceLock<f64>,

    /// Cached 2π/m
    #[cfg_attr(feature = "serde1", serde(skip))]
    twopi_over_m: OnceLock<f64>,
}
```
to
```rust
pub struct Cdvm {
    /// Number of categories
    modulus: usize,

    /// Underlying scaled von Mises distribution
    parent: Scaled<VonMises>,

    /// Cached log-normalization constant
    #[cfg_attr(feature = "serde1", serde(skip))]
    log_norm_const: OnceLock<f64>,
}
```

The main advantage of this is that it makes it simple and cheap to work with cdvm in terms of `Scaled<VonMises>`, so we can reuse inference code