### PR TITLE
CDVM rework

### DIFF
--- a/benches/vonmises.rs
+++ b/benches/vonmises.rs
@@ -6,6 +6,7 @@ use criterion::Criterion;
 use criterion::PlotConfiguration;
 use criterion::{criterion_group, criterion_main};
 use rand::Rng;
+use rv::consts::TWO_PI;
 use rv::dist::VonMises;
 use rv::misc::bessel::log_i0;
 use rv::prelude::*;
@@ -51,7 +52,7 @@ fn bench_vm_ln_f(c: &mut Criterion) {
             b.iter_batched_ref(
                 rand::thread_rng,
                 |rng| {
-                    let x: f64 = rng.gen_range(0.0..2.0 * PI);
+                    let x: f64 = rng.gen_range(0.0..TWO_PI);
                     black_box(vm.ln_f(&x));
                 },
                 BatchSize::SmallInput,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -18,3 +18,5 @@ pub const EULER_MASCERONI: f64 = 0.577_215_664_901_532_9;
 pub const LN_LN_2: f64 = -0.366_512_920_581_664_3;
 /// ln(2 * pi * e)
 pub const LN_2PI_E: f64 = 2.837_877_066_409_345_3;
+
+pub const TWO_PI: f64 = std::f64::consts::TAU;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -535,7 +535,7 @@ mod tests {
         struct MockPosterior(Gaussian);
 
         impl Sampleable<Gaussian> for MockPosterior {
-            fn draw<R: Rng>(&self, rng: &mut R) -> Gaussian {
+            fn draw<R: Rng>(&self, _rng: &mut R) -> Gaussian {
                 self.0.clone()
             }
         }

--- a/src/data/stat/cdvm.rs
+++ b/src/data/stat/cdvm.rs
@@ -2,6 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::traits::SuffStat;
+use crate::consts::TWO_PI;
 
 /// Cdvm sufficient statistic.
 ///
@@ -21,7 +22,6 @@ pub struct CdvmSuffStat {
     sum_cos: f64,
 
     /// Cached 2π/m
-    #[cfg_attr(feature = "serde1", serde(skip))]
     twopi_over_m: f64,
 }
 
@@ -33,7 +33,7 @@ impl CdvmSuffStat {
             n: 0,
             sum_sin: 0.0,
             sum_cos: 0.0,
-            twopi_over_m: 2.0 * std::f64::consts::PI / modulus as f64,
+            twopi_over_m: TWO_PI / modulus as f64,
         }
     }
 
@@ -51,7 +51,7 @@ impl CdvmSuffStat {
             n,
             sum_sin,
             sum_cos,
-            twopi_over_m: 2.0 * std::f64::consts::PI / modulus as f64,
+            twopi_over_m: TWO_PI / modulus as f64,
         }
     }
 
@@ -97,9 +97,6 @@ impl SuffStat<usize> for CdvmSuffStat {
     }
 
     fn observe(&mut self, x: &usize) {
-        if *x >= self.modulus {
-            panic!("x must be less than modulus");
-        }
         let angle = self.twopi_over_m * (*x as f64);
         let (sin_x, cos_x) = angle.sin_cos();
         self.sum_sin += sin_x;
@@ -108,9 +105,6 @@ impl SuffStat<usize> for CdvmSuffStat {
     }
 
     fn forget(&mut self, x: &usize) {
-        if *x >= self.modulus {
-            panic!("x must be less than modulus");
-        }
         let angle = self.twopi_over_m * (*x as f64);
         let (sin_x, cos_x) = angle.sin_cos();
         self.sum_sin -= sin_x;
@@ -172,20 +166,6 @@ mod tests {
         stat1.observe(&1);
         stat1.merge(stat2);
         assert_eq!(stat1.n(), 1);
-    }
-
-    #[test]
-    #[should_panic(expected = "x must be less than modulus")]
-    fn observe_panics_if_x_too_large() {
-        let mut stat = CdvmSuffStat::new(4);
-        stat.observe(&4);
-    }
-
-    #[test]
-    #[should_panic(expected = "x must be less than modulus")]
-    fn forget_panics_if_x_too_large() {
-        let mut stat = CdvmSuffStat::new(4);
-        stat.forget(&4);
     }
 
     #[test]

--- a/src/data/stat/cdvm.rs
+++ b/src/data/stat/cdvm.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
-use crate::traits::SuffStat;
 use crate::consts::TWO_PI;
+use crate::traits::SuffStat;
 
 /// Cdvm sufficient statistic.
 ///

--- a/src/data/stat/scaled.rs
+++ b/src/data/stat/scaled.rs
@@ -9,8 +9,6 @@ use serde::{Deserialize, Serialize};
 pub struct ScaledSuffStat<S> {
     parent: S,
     scale: f64,
-
-    #[cfg_attr(feature = "serde1", serde(skip))]
     rate: f64,
 }
 

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -103,7 +103,7 @@ impl Cdvm {
             return Err(CdvmError::InvalidCategories { modulus });
         }
 
-        Ok(Cdvm::new_unchecked(mu, k, modulus))
+        Ok(Cdvm::new_unchecked(modulus, mu, k))
     }
 
     // Test that dependent fields are properly set
@@ -119,7 +119,7 @@ impl Cdvm {
 
     /// Creates a new CDVM without checking whether the parameters are valid.
     #[inline]
-    pub fn new_unchecked(mu: f64, k: f64, modulus: usize) -> Self {
+    pub fn new_unchecked(modulus: usize, mu: f64, k: f64) -> Self {
         let log_norm_const = Cdvm::compute_log_norm_const(modulus, mu, k);
 
         Cdvm {

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -110,6 +110,7 @@ impl Cdvm {
 
     // Test that dependent fields are properly set
     // This is just for testing purposes
+    #[must_use]
     pub fn is_consistent(&self) -> bool {
         let other = Cdvm::new(self.modulus, self.mu, self.k).unwrap();
         self.mu == other.mu
@@ -146,21 +147,25 @@ impl Cdvm {
     }
 
     /// Get the number of categories
+    #[must_use]
     pub fn modulus(&self) -> usize {
         self.modulus
     }
 
     /// Get the von Mises mean direction
+    #[must_use]
     pub fn mu(&self) -> f64 {
         self.mu
     }
 
     /// Get the von Mises concentration parameter
+    #[must_use]
     pub fn k(&self) -> f64 {
         self.k
     }
 
     /// Get the cached 2π/m
+    #[must_use]
     pub fn twopi_over_m(&self) -> f64 {
         self.twopi_over_m
     }
@@ -257,13 +262,13 @@ impl fmt::Display for CdvmError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MuNotFinite { mu } => {
-                write!(f, "mu ({}) must be finite", mu)
+                write!(f, "mu ({mu}) must be finite")
             }
             Self::KNotFinite { k } => {
-                write!(f, "k ({}) must be finite", k)
+                write!(f, "k ({k}) must be finite")
             }
             Self::KNegative { k } => {
-                write!(f, "k ({}) must be non-negative", k)
+                write!(f, "k ({k}) must be non-negative")
             }
             Self::InvalidCategories { modulus } => {
                 write!(f, "number of categories ({modulus}) must be at least 2")

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -79,7 +79,6 @@ pub enum CdvmError {
 
     /// The number of categories is less than 2
     InvalidCategories { modulus: usize },
-
 }
 
 impl Cdvm {
@@ -105,7 +104,12 @@ impl Cdvm {
     }
 
     pub fn is_consistent(&self) -> bool {
-        Cdvm::new(self.mu, self.k, self.modulus).unwrap() == *self
+        let other = Cdvm::new(self.mu, self.k, self.modulus).unwrap();
+        self.mu == other.mu
+            && self.k == other.k
+            && self.modulus == other.modulus
+            && self.log_norm_const == other.log_norm_const
+            && self.twopi_over_m == other.twopi_over_m
     }
 
     /// Creates a new CDVM without checking whether the parameters are valid.
@@ -169,7 +173,8 @@ impl Cdvm {
 
     pub fn set_mu_unchecked(&mut self, mu: f64) {
         self.mu = mu;
-        self.log_norm_const = Cdvm::compute_log_norm_const(self.modulus, self.mu, self.k);
+        self.log_norm_const =
+            Cdvm::compute_log_norm_const(self.modulus, mu, self.k);
     }
 
     /// Set the concentration parameter
@@ -186,7 +191,8 @@ impl Cdvm {
 
     pub fn set_k_unchecked(&mut self, k: f64) {
         self.k = k;
-        self.log_norm_const = Cdvm::compute_log_norm_const(self.modulus, self.mu, k);
+        self.log_norm_const =
+            Cdvm::compute_log_norm_const(self.modulus, self.mu, k);
     }
 }
 
@@ -442,12 +448,12 @@ mod tests {
         ) {
             let mu = mu % (m as f64);
             let mut cdvm = Cdvm::new(mu, k1, m).unwrap();
-            
+
             // Set a new k value
             cdvm.set_k(k2).unwrap();
-            
+
             // Check that the distribution is still consistent
-            prop_assert!(cdvm.is_consistent(), 
+            prop_assert!(cdvm.is_consistent(),
                 "CDVM not consistent after set_k: m={}, mu={}, k1={}, k2={}", m, mu, k1, k2);
         }
     }
@@ -463,12 +469,12 @@ mod tests {
             let mu1 = mu1 % (m as f64);
             let mu2 = mu2 % (m as f64);
             let mut cdvm = Cdvm::new(mu1, k, m).unwrap();
-            
+
             // Set a new mu value
             cdvm.set_mu(mu2).unwrap();
-            
+
             // Check that the distribution is still consistent
-            prop_assert!(cdvm.is_consistent(), 
+            prop_assert!(cdvm.is_consistent(),
                 "CDVM not consistent after set_mu: m={}, mu1={}, mu2={}, k={}", m, mu1, mu2, k);
         }
     }

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -103,6 +103,8 @@ impl Cdvm {
         Ok(Cdvm::new_unchecked(mu, k, modulus))
     }
 
+    // Test that dependent fields are properly set
+    // This is just for testing purposes
     pub fn is_consistent(&self) -> bool {
         let other = Cdvm::new(self.mu, self.k, self.modulus).unwrap();
         self.mu == other.mu

--- a/src/dist/cdvm.rs
+++ b/src/dist/cdvm.rs
@@ -93,6 +93,9 @@ impl Cdvm {
         if !mu.is_finite() {
             return Err(CdvmError::MuNotFinite { mu });
         }
+        if !k.is_finite() {
+            return Err(CdvmError::KNotFinite { k });
+        }
         if k < 0.0 {
             return Err(CdvmError::KNegative { k });
         }

--- a/src/dist/ks.rs
+++ b/src/dist/ks.rs
@@ -4,6 +4,7 @@
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
+use crate::consts::TWO_PI;
 use crate::impl_display;
 use crate::traits::*;
 use rand::Rng;
@@ -80,7 +81,7 @@ impl KsTwoAsymptotic {
             let mut p: f64 = 1.0;
             let mut d: f64 = 0.0;
 
-            let w = (2.0 * PI).sqrt() / x;
+            let w = TWO_PI.sqrt() / x;
             let logu8 = -PI * PI / (x * x);
             let u = (logu8 / 8.0).exp();
 

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -2,6 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::consts::LN_2PI;
+use crate::consts::TWO_PI;
 use crate::data::VonMisesSuffStat;
 use crate::impl_display;
 use crate::misc::bessel;
@@ -116,7 +117,7 @@ impl VonMises {
         } else if !k.is_finite() {
             Err(VonMisesError::KNotFinite { k })
         } else {
-            let mu = mu.rem_euclid(2.0 * PI);
+            let mu = mu.rem_euclid(TWO_PI);
             let (sin_mu, cos_mu) = mu.sin_cos();
             let log_i0_k = bessel::log_i0(k);
             Ok(VonMises {
@@ -219,7 +220,7 @@ impl VonMises {
         if !mu.is_finite() {
             Err(VonMisesError::MuNotFinite { mu })
         } else {
-            self.set_mu_unchecked(mu.rem_euclid(2.0 * PI));
+            self.set_mu_unchecked(mu.rem_euclid(TWO_PI));
             Ok(())
         }
     }
@@ -320,7 +321,7 @@ impl VonMises {
         // Sample uniformly on [-xmax, xmax] and add μ
         let x = xmax.mul_add(rng.gen_range(-1.0..=1.0), mu);
         // Ensure result is in [0, 2π)
-        x.rem_euclid(2.0 * PI)
+        x.rem_euclid(TWO_PI)
     }
 }
 
@@ -354,10 +355,10 @@ macro_rules! impl_traits {
             // https://www.researchgate.net/publication/246035131_Efficient_Simulation_of_the_von_Mises_Distribution
             fn draw<R: Rng>(&self, rng: &mut R) -> $kind {
                 if self.k.is_zero() {
-                    rng.gen_range(0.0..=2.0 * PI) as $kind
+                    rng.gen_range(0.0..=TWO_PI) as $kind
                 } else if self.k > 700.0 {
                     let normal = Normal::new(self.mu, 1.0 / self.k).unwrap();
-                    rng.sample(normal).rem_euclid(2.0 * PI) as $kind
+                    rng.sample(normal).rem_euclid(TWO_PI) as $kind
                 } else {
                     let tau =
                         1.0 + 4.0_f64.mul_add(self.k * self.k, 1.0).sqrt();
@@ -393,7 +394,7 @@ macro_rules! impl_traits {
                     } else {
                         self.mu - acf
                     };
-                    x.rem_euclid(2.0 * PI) as $kind
+                    x.rem_euclid(TWO_PI) as $kind
                 }
             }
         }
@@ -422,7 +423,7 @@ macro_rules! impl_traits {
         impl Support<$kind> for VonMises {
             fn supports(&self, x: &$kind) -> bool {
                 let xf = f64::from(*x);
-                (0.0..=2.0 * PI).contains(&xf)
+                (0.0..=TWO_PI).contains(&xf)
             }
         }
 
@@ -516,7 +517,7 @@ mod tests {
     fn new_should_allow_mu_in_0_2pi() {
         assert!(VonMises::new(0.0, 1.0).is_ok());
         assert!(VonMises::new(PI, 1.0).is_ok());
-        assert!(VonMises::new(2.0 * PI, 1.0).is_ok());
+        assert!(VonMises::new(TWO_PI, 1.0).is_ok());
     }
 
     #[test]

--- a/src/process/gaussian/kernel/exp_sin_squared.rs
+++ b/src/process/gaussian/kernel/exp_sin_squared.rs
@@ -295,10 +295,11 @@ mod tests {
 
     #[test]
     fn expsinesquared_kernel_b() -> Result<(), KernelError> {
+        use crate::consts::TWO_PI;
         let x: DMatrix<f64> =
             DMatrix::from_row_slice(5, 1, &[-4.0, -3.0, -2.0, -1.0, 1.0]);
         // Non default variables
-        let kernel = ExpSineSquaredKernel::new(5.0, 2.0 * f64::consts::PI)?;
+        let kernel = ExpSineSquaredKernel::new(5.0, TWO_PI)?;
         let (cov, grad) = kernel.covariance_with_gradient(&x)?;
         let expected_cov = DMatrix::from_row_slice(
             5,


### PR DESCRIPTION
# Circular Distribution von Mises (CDVM) Refactoring

This PR improves the Circular Distribution von Mises (CDVM) implementation with several key enhancements:

## Key Changes

1. **New `TWO_PI` constant**
   - Added a `TWO_PI` constant (using Rust's standard `TAU`) in `consts.rs`
   - Replaced all occurrences of `2.0 * std::f64::consts::PI` with this constant

2. **CDVM API Improvements**
   - Reordered constructor parameters to more logical order: `Cdvm::new(modulus, mu, k)`
   - Renamed `kappa` parameter to more concise `k` for consistency
   - Improved caching strategy by removing `OnceLock` and calculating values at initialization
   - Added `set_mu` and `set_k` methods for modifying parameters after construction

3. **Removed Range Checks**
   - Removed unnecessary range checks in `CdvmSuffStat::observe` and `forget` methods
   - The methods now handle inputs outside valid range by performing calculations anyway
   - This improves performance in hot paths

4. **Additional Error Types**
   - Added more specific error types for parameter validation
   - New errors include `MuNotFinite`, `KNotFinite`, and `KNegative`

5. **Better Serialization Support**
   - Fixed serialization attributes on cached fields to ensure they're properly included
   - This maintains correctness when deserializing instances

## Implementation Details

- Refactored the normalization constant calculation into a separate static method
- Added `is_consistent` helper method for testing 
- Fixed inconsistent parameter ordering in the API
- Updated all unit tests and property-based tests to use the new API

## Performance Improvements

The PR reduces unnecessary calculations and improves caching strategy, which should provide better performance for CDVM-based applications.