### PR TITLE
chore: bump to rand 0.9 / rand_distr 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,8 +67,8 @@ dependencies = [
  "instant",
  "num-traits",
  "paste",
- "rand",
- "rand_xoshiro",
+ "rand 0.8.5",
+ "rand_xoshiro 0.6.0",
  "thiserror",
 ]
 
@@ -84,7 +84,7 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "thiserror",
 ]
 
@@ -327,7 +327,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -640,8 +652,8 @@ dependencies = [
  "peroxide-ad",
  "peroxide-num",
  "puruspe",
- "rand",
- "rand_distr",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
 ]
 
 [[package]]
@@ -717,8 +729,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -748,14 +760,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -765,7 +793,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -774,7 +812,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -784,7 +831,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -793,7 +850,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -802,7 +859,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
  "serde",
 ]
 
@@ -904,9 +970,9 @@ dependencies = [
  "num-traits",
  "peroxide",
  "proptest",
- "rand",
- "rand_distr",
- "rand_xoshiro",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
+ "rand_xoshiro 0.7.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1133,6 +1199,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1371,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,25 +58,25 @@ dependencies = [
 
 [[package]]
 name = "argmin"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760a49d596b18b881d2fe6e9e6da4608fa64d4a7653ef5cd43bfaa4da018d596"
+checksum = "e7ab7ca97779074715a402e5e8045fae27e7191acaec9b4c5653276316e9e404"
 dependencies = [
  "anyhow",
  "argmin-math",
- "instant",
  "num-traits",
  "paste",
- "rand 0.8.5",
- "rand_xoshiro 0.6.0",
+ "rand 0.9.2",
+ "rand_xoshiro",
  "thiserror",
+ "web-time",
 ]
 
 [[package]]
 name = "argmin-math"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93a0d0269b60bd1cd674de70314e3f0da97406cf8c1936ce760d2a46e0f13fe"
+checksum = "d911cbb56eafdcaf7e84e101288196d3b07184ed2029a7142045102a93fb0307"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -84,7 +84,7 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.9.2",
  "thiserror",
 ]
 
@@ -385,15 +385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,7 +517,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -711,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -855,15 +846,6 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
@@ -972,7 +954,7 @@ dependencies = [
  "proptest",
  "rand 0.9.2",
  "rand_distr 0.5.1",
- "rand_xoshiro 0.7.0",
+ "rand_xoshiro",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1020,7 +1002,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1083,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1106,22 +1088,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1237,7 +1219,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -1259,7 +1241,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1275,6 +1257,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1405,7 +1397,7 @@ checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1416,5 +1408,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.106",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ github = { repository = "promised-ai/rv", tag = "v0.17.0" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-argmin = { version = "0.10", optional = true }
-argmin-math = { version = "0.4", optional = true, features = ["nalgebra_v0_32"] }
+argmin = { version = "0.11", optional = true }
+argmin-math = { version = "0.5", optional = true, features = ["nalgebra_v0_32"] }
 doc-comment = "0.3"
 lru = "0.12"
 nalgebra = { version = "0.32", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ doc-comment = "0.3"
 lru = "0.12"
 nalgebra = { version = "0.32", optional = true }
 num = "0.4"
-rand = { version = "0.8", features = ["small_rng"] }
-rand_distr = "0.4"
+rand = { version = "0.9", features = ["small_rng"] }
+rand_distr = "0.5"
 serde = {version = "1", features = ["derive"], optional = true}
 special = "0.10"
 num-traits = "0.2"
-rand_xoshiro = { version = "0.6", optional = true, features=["serde1"]}
+rand_xoshiro = { version = "0.7", optional = true, features=["serde"]}
 itertools = "0.13"
 
 [dev-dependencies]
@@ -40,7 +40,7 @@ proptest = "1.5"
 serde_yaml = "0.9"
 serde_json = "1"
 approx = "0.5"
-rand_xoshiro = "0.6"
+rand_xoshiro = "0.7"
 
 [features]
 serde1 = ["serde", "nalgebra/serde-serialize"]

--- a/benches/beta.rs
+++ b/benches/beta.rs
@@ -16,14 +16,14 @@ fn draw_rv<R: rand::Rng>(mut rng: &mut R) -> f64 {
 }
 
 fn draw_2u<R: rand::Rng>(rng: &mut R) -> f64 {
-    let a = rng.gen::<f64>().powf(1.0 / 5.0);
-    let b = rng.gen::<f64>().powf(1.0 / 2.0);
+    let a = rng.random::<f64>().powf(1.0 / 5.0);
+    let b = rng.random::<f64>().powf(1.0 / 2.0);
     a / (a + b)
 }
 
 fn draw_2u_recip<R: rand::Rng>(rng: &mut R) -> f64 {
-    let a = rng.gen::<f64>().powf(5.0_f64.recip());
-    let b = rng.gen::<f64>().powf(2.0_f64.recip());
+    let a = rng.random::<f64>().powf(5.0_f64.recip());
+    let b = rng.random::<f64>().powf(2.0_f64.recip());
 
     a / (a + b)
 }
@@ -32,20 +32,20 @@ fn bench_beta_draw(c: &mut Criterion) {
     let mut group = c.benchmark_group("beta_draw");
     group.bench_function("rand_distr", |b| {
         b.iter(|| {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             draw_rand_distr(&mut rng)
         })
     });
     group.bench_function("draw_rv", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         b.iter(|| draw_rv(&mut rng))
     });
     group.bench_function("draw_2_uniform", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         b.iter(|| draw_2u(&mut rng))
     });
     group.bench_function("draw_2_uniform_recip", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         b.iter(|| draw_2u_recip(&mut rng))
     });
 }
@@ -69,14 +69,14 @@ fn bench_beta_vs_kumaraswamy_ln_pdf(c: &mut Criterion) {
 fn bench_beta_vs_kumaraswamy_draw(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench_beta_vs_kumaraswamy_draw");
     group.bench_function("beta", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let beta = rv::dist::Beta::new(1.0, 2.0).unwrap();
         b.iter(|| {
             let _x: f64 = beta.draw(&mut rng);
         });
     });
     group.bench_function("kumaraswamy", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let kuma = rv::dist::Kumaraswamy::new(1.0, 2.0).unwrap();
         b.iter(|| {
             let _x: f64 = kuma.draw(&mut rng);

--- a/benches/categorical.rs
+++ b/benches/categorical.rs
@@ -10,7 +10,7 @@ fn bench_cat_draw(c: &mut Criterion) {
         let cat = &Categorical::uniform(k);
         group.bench_function(&format!("u8, k = {}", k), move |b| {
             b.iter_batched_ref(
-                rand::thread_rng,
+                rand::rng,
                 |mut rng| {
                     let _x: u8 = cat.draw(&mut rng);
                 },
@@ -19,7 +19,7 @@ fn bench_cat_draw(c: &mut Criterion) {
         });
         group.bench_function(&format!("usize, k = {}", k), move |b| {
             b.iter_batched_ref(
-                rand::thread_rng,
+                rand::rng,
                 |mut rng| {
                     let _x: usize = cat.draw(&mut rng);
                 },

--- a/benches/gev.rs
+++ b/benches/gev.rs
@@ -8,7 +8,7 @@ fn bench_gev_draw_0(c: &mut Criterion) {
     let gev = Gev::new(0.0, 1.0, 0.0).unwrap();
     c.bench_function("GEV(0, 1, 0), draw 1", move |b| {
         b.iter_batched_ref(
-            rand::thread_rng,
+            rand::rng,
             |mut rng| {
                 let _x: f64 = gev.draw(&mut rng);
             },
@@ -21,7 +21,7 @@ fn bench_gev_draw_one_half(c: &mut Criterion) {
     let gev = Gev::new(0.0, 1.0, 0.5).unwrap();
     c.bench_function("GEV(0, 1, 0.5), draw 1", move |b| {
         b.iter_batched_ref(
-            rand::thread_rng,
+            rand::rng,
             |mut rng| {
                 let _x: f64 = gev.draw(&mut rng);
             },
@@ -34,7 +34,7 @@ fn bench_gev_draw_negative_one_half(c: &mut Criterion) {
     let gev = Gev::new(0.0, 1.0, -0.5).unwrap();
     c.bench_function("GEV(0, 1, -0.5), draw 1", move |b| {
         b.iter_batched_ref(
-            rand::thread_rng,
+            rand::rng,
             |mut rng| {
                 let _x: f64 = gev.draw(&mut rng);
             },

--- a/benches/mixture_entropy.rs
+++ b/benches/mixture_entropy.rs
@@ -11,7 +11,7 @@ fn bench_gmm_entropy(c: &mut Criterion) {
     c.bench_function("4-component GMM entropy", move |b| {
         b.iter_batched_ref(
             || {
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 let weights: Vec<f64> = symdir.draw(&mut rng);
                 let components: Vec<Gaussian> = ng.sample(4, &mut rng);
                 Mixture::new(weights, components).unwrap()

--- a/benches/unit_powerlaw.rs
+++ b/benches/unit_powerlaw.rs
@@ -10,14 +10,14 @@ fn draw_rv<R: rand::Rng>(mut rng: &mut R) -> f64 {
 }
 
 fn draw_2u<R: rand::Rng>(rng: &mut R) -> f64 {
-    let a = rng.gen::<f64>().powf(1.0 / 5.0);
-    let b = rng.gen::<f64>().powf(1.0 / 2.0);
+    let a = rng.random::<f64>().powf(1.0 / 5.0);
+    let b = rng.random::<f64>().powf(1.0 / 2.0);
     a / (a + b)
 }
 
 fn draw_2u_recip<R: rand::Rng>(rng: &mut R) -> f64 {
-    let a = rng.gen::<f64>().powf(5.0_f64.recip());
-    let b = rng.gen::<f64>().powf(2.0_f64.recip());
+    let a = rng.random::<f64>().powf(5.0_f64.recip());
+    let b = rng.random::<f64>().powf(2.0_f64.recip());
 
     a / (a + b)
 }
@@ -25,15 +25,15 @@ fn draw_2u_recip<R: rand::Rng>(rng: &mut R) -> f64 {
 fn bench_powlaw_draw(c: &mut Criterion) {
     let mut group = c.benchmark_group("unit_powerlaw_draw");
     group.bench_function("draw_rv", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         b.iter(|| draw_rv(&mut rng))
     });
     group.bench_function("draw_2_uniform", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         b.iter(|| draw_2u(&mut rng))
     });
     group.bench_function("draw_2_uniform_recip", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         b.iter(|| draw_2u_recip(&mut rng))
     });
 }
@@ -63,21 +63,21 @@ fn bench_powlaw_beta_kumaraswamy_ln_pdf(c: &mut Criterion) {
 fn bench_powlaw_beta_kumaraswamy_draw(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench_powlaw_beta_kumaraswamy_draw");
     group.bench_function("powlaw", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let beta = rv::dist::UnitPowerLaw::new(2.0).unwrap();
         b.iter(|| {
             let _x: f64 = beta.draw(&mut rng);
         });
     });
     group.bench_function("beta", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let beta = rv::dist::Beta::new(2.0, 1.0).unwrap();
         b.iter(|| {
             let _x: f64 = beta.draw(&mut rng);
         });
     });
     group.bench_function("kumaraswamy", |b| {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let kuma = rv::dist::Kumaraswamy::new(2.0, 1.0).unwrap();
         b.iter(|| {
             let _x: f64 = kuma.draw(&mut rng);

--- a/examples/cat_enum.rs
+++ b/examples/cat_enum.rs
@@ -30,7 +30,7 @@ impl CategoricalDatum for Color {
 }
 
 fn main() {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let ctgrl = Categorical::new(&[0.25, 0.25, 0.5]).unwrap();
 

--- a/examples/coin_flips.rs
+++ b/examples/coin_flips.rs
@@ -6,13 +6,13 @@ use rv::ConjugateModel;
 use std::sync::Arc;
 
 fn main() {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // Generate some 1000 coin flips from a coin that will come up head 70%
     // of the time.
     let flips: Vec<bool> = (0..1000)
         .map(|_| {
-            let x: f64 = rng.gen();
+            let x: f64 = rng.random();
             x < 0.7
         })
         .collect();

--- a/examples/die_rolls.rs
+++ b/examples/die_rolls.rs
@@ -3,7 +3,7 @@ use rv::prelude::CategoricalData;
 use rv::traits::*;
 
 fn main() {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // Roll a die (0...5) that comes up 5 half the time
     let ctgrl = Categorical::new(&[1.0, 1.0, 1.0, 1.0, 1.0, 5.0]).unwrap();

--- a/examples/estimate_pi.rs
+++ b/examples/estimate_pi.rs
@@ -19,8 +19,8 @@ fn main() {
     let u = Uniform::new(-1.0, 1.0).unwrap();
 
     // The rand number steam consumes the rng
-    let mut rng1 = rand::thread_rng();
-    let mut rng2 = rand::thread_rng();
+    let mut rng1 = rand::rng();
+    let mut rng2 = rand::rng();
 
     let pi_est = u
         .sample_stream(&mut rng1)

--- a/examples/gauss_prior_geweke.rs
+++ b/examples/gauss_prior_geweke.rs
@@ -37,7 +37,7 @@ fn mean_var(xs: &[f64]) -> (f64, f64) {
 // compiler does type inference.
 macro_rules! geweke {
     ($pr: expr) => {{
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut results: BTreeMap<String, Vec<f64>> = BTreeMap::new();
         for i in 0..N_RUNS {
             print_flush!(".");

--- a/examples/sbd.rs
+++ b/examples/sbd.rs
@@ -1,6 +1,3 @@
-use rand::SeedableRng;
-use rv::prelude::*;
-
 #[cfg(feature = "experimental")]
 use rv::experimental::stick_breaking_process::{
     StickBreaking, StickBreakingDiscrete, StickSequence,

--- a/examples/stickbreaking_posterior.rs
+++ b/examples/stickbreaking_posterior.rs
@@ -1,7 +1,3 @@
-use itertools::Either;
-use peroxide::statistics::stat::Statistics;
-use rv::prelude::*;
-
 #[cfg(feature = "experimental")]
 use rv::experimental::stick_breaking_process::*;
 

--- a/src/dist/bernoulli.rs
+++ b/src/dist/bernoulli.rs
@@ -506,7 +506,7 @@ mod tests {
 
     #[test]
     fn sample_bools_should_draw_the_correct_number_of_samples() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let n = 103;
         let xs: Vec<bool> = Bernoulli::uniform().sample(n, &mut rng);
         assert_eq!(xs.len(), n);
@@ -514,7 +514,7 @@ mod tests {
 
     #[test]
     fn sample_ints_should_draw_the_correct_number_of_samples() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let n = 103;
         let xs: Vec<i16> = Bernoulli::uniform().sample(n, &mut rng);
         assert_eq!(xs.len(), n);
@@ -694,7 +694,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let b = Bernoulli::new(0.7).unwrap();
         let ps: Vec<f64> = vec![0.3, 0.7];
 

--- a/src/dist/beta.rs
+++ b/src/dist/beta.rs
@@ -598,7 +598,7 @@ mod tests {
 
     #[test]
     fn draw_should_return_values_within_0_to_1() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let beta = Beta::jeffreys();
         for _ in 0..100 {
             let x = beta.draw(&mut rng);
@@ -608,7 +608,7 @@ mod tests {
 
     #[test]
     fn sample_returns_the_correct_number_draws() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let beta = Beta::jeffreys();
         let xs: Vec<f32> = beta.sample(103, &mut rng);
         assert_eq!(xs.len(), 103);
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn draw_test_alpha_beta_gt_one() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let beta = Beta::new(1.2, 3.4).unwrap();
         let cdf = |x: f64| beta.cdf(&x);
 
@@ -724,7 +724,7 @@ mod tests {
 
     #[test]
     fn draw_test_alpha_beta_lt_one() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let beta = Beta::new(0.2, 0.7).unwrap();
         let cdf = |x: f64| beta.cdf(&x);
 
@@ -744,7 +744,7 @@ mod tests {
 
     #[test]
     fn beta_u_should_never_draw_1() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let beta = Beta::new(0.5, 0.5).unwrap();
 
         let some_1 = beta
@@ -771,21 +771,21 @@ mod tests {
 
     #[test]
     fn set_alpha() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         for _ in 0..100 {
-            let a1 = rng.gen::<f64>();
-            let b1 = rng.gen::<f64>();
+            let a1 = rng.random::<f64>();
+            let b1 = rng.random::<f64>();
             let mut beta1 = Beta::new(a1, b1).unwrap();
 
             // Any value in the unit interval
-            let x: f64 = rng.gen();
+            let x: f64 = rng.random();
 
             // Evaluate the pdf to force computation of `ln_beta_ab`
             let _ = beta1.pdf(&x);
 
             // Next we'll `set_alpha` to a2, and compare with a fresh Beta
-            let a2 = rng.gen::<f64>();
+            let a2 = rng.random::<f64>();
 
             // Setting the new values
             beta1.set_alpha(a2).unwrap();
@@ -802,21 +802,21 @@ mod tests {
 
     #[test]
     fn set_beta() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         for _ in 0..100 {
-            let a1 = rng.gen::<f64>();
-            let b1 = rng.gen::<f64>();
+            let a1 = rng.random::<f64>();
+            let b1 = rng.random::<f64>();
             let mut beta1 = Beta::new(a1, b1).unwrap();
 
             // Any value in the unit interval
-            let x: f64 = rng.gen();
+            let x: f64 = rng.random();
 
             // Evaluate the pdf to force computation of `ln_beta_ab`
             let _ = beta1.pdf(&x);
 
             // Next we'll `set_beta` to b2, and compare this with a fresh Beta
-            let b2 = rng.gen::<f64>();
+            let b2 = rng.random::<f64>();
 
             // Setting the new values
             beta1.set_beta(b2).unwrap();

--- a/src/dist/binomial.rs
+++ b/src/dist/binomial.rs
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     fn sample_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let binom = Binomial::new(5, 0.6).unwrap();
         let ps: Vec<f64> = vec![
             0.010_240_000_000_000_008,
@@ -504,7 +504,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let binom = Binomial::new(5, 0.6).unwrap();
         let ps: Vec<f64> = vec![
             0.010_240_000_000_000_008,

--- a/src/dist/categorical.rs
+++ b/src/dist/categorical.rs
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn draw_should_return_numbers_in_0_to_k() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let k = 5;
         let cat = Categorical::uniform(k);
         let mut counts = vec![0; k];
@@ -397,7 +397,7 @@ mod tests {
 
     #[test]
     fn sample_should_return_the_correct_number_of_draws() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let cat = Categorical::uniform(5);
         let xs: Vec<u8> = cat.sample(103, &mut rng);
         assert_eq!(xs.len(), 103);
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let cat = Categorical::new(&[1.0, 2.0, 3.0, 4.0]).unwrap();
         let ps: Vec<f64> = vec![0.1, 0.2, 0.3, 0.4];
 

--- a/src/dist/cauchy.rs
+++ b/src/dist/cauchy.rs
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn inv_cdf_ident() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let c = Cauchy::default();
         for _ in 0..100 {
             let x: f64 = c.draw(&mut rng);
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let c = Cauchy::new(1.2, 3.4).unwrap();
         let cdf = |x: f64| c.cdf(&x);
 

--- a/src/dist/chi_squared.rs
+++ b/src/dist/chi_squared.rs
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let x2 = ChiSquared::new(2.5).unwrap();
         let cdf = |x: f64| x2.cdf(&x);
 

--- a/src/dist/dirichlet.rs
+++ b/src/dist/dirichlet.rs
@@ -531,7 +531,7 @@ mod tests {
 
         #[test]
         fn draws_should_be_in_support() {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             // Small alphas gives us more variability in the simplex, and more
             // variability gives us a better test.
             let dir = Dirichlet::jeffreys(10).unwrap();
@@ -543,7 +543,7 @@ mod tests {
 
         #[test]
         fn sample_should_return_the_proper_number_of_draws() {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let dir = Dirichlet::jeffreys(3).unwrap();
             let xs: Vec<Vec<f64>> = dir.sample(88, &mut rng);
             assert_eq!(xs.len(), 88);
@@ -593,7 +593,7 @@ mod tests {
 
         #[test]
         fn sample_should_return_the_proper_number_of_draws() {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let symdir = SymmetricDirichlet::jeffreys(3).unwrap();
             let xs: Vec<Vec<f64>> = symdir.sample(88, &mut rng);
             assert_eq!(xs.len(), 88);
@@ -618,7 +618,7 @@ mod tests {
 
         #[test]
         fn draws_should_be_in_support() {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             // Small alphas gives us more variability in the simplex, and more
             // variability gives us a better test.
             let symdir = SymmetricDirichlet::jeffreys(10).unwrap();

--- a/src/dist/dirichlet/categorical_prior.rs
+++ b/src/dist/dirichlet/categorical_prior.rs
@@ -252,7 +252,7 @@ mod test {
 
         #[test]
         fn symmetric_prior_draw_log_weights_should_all_be_negative() {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let csd = SymmetricDirichlet::new(1.0, 4).unwrap();
             let ctgrl: Categorical = csd.draw(&mut rng);
 
@@ -261,7 +261,7 @@ mod test {
 
         #[test]
         fn symmetric_prior_draw_log_weights_should_be_unique() {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let csd = SymmetricDirichlet::new(1.0, 4).unwrap();
             let ctgrl: Categorical = csd.draw(&mut rng);
 
@@ -277,7 +277,7 @@ mod test {
 
         #[test]
         fn symmetric_posterior_draw_log_weights_should_all_be_negative() {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
 
             let xs: Vec<u8> = vec![0, 1, 2, 1, 2, 3, 0, 1, 1];
             let data: CategoricalData<u8> = DataOrSuffStat::Data(&xs);
@@ -291,7 +291,7 @@ mod test {
 
         #[test]
         fn symmetric_posterior_draw_log_weights_should_be_unique() {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
 
             let xs: Vec<u8> = vec![0, 1, 2, 1, 2, 3, 0, 1, 1];
             let data: CategoricalData<u8> = DataOrSuffStat::Data(&xs);

--- a/src/dist/discrete_uniform.rs
+++ b/src/dist/discrete_uniform.rs
@@ -139,12 +139,12 @@ where
     X: Integer + From<T>,
 {
     fn draw<R: Rng>(&self, rng: &mut R) -> X {
-        let d = rand::distributions::Uniform::new_inclusive(self.a, self.b);
+        let d = rand_distr::Uniform::new_inclusive(self.a, self.b).unwrap();
         X::from(rng.sample(d))
     }
 
     fn sample<R: Rng>(&self, n: usize, rng: &mut R) -> Vec<X> {
-        let d = rand::distributions::Uniform::new_inclusive(self.a, self.b);
+        let d = rand_distr::Uniform::new_inclusive(self.a, self.b).unwrap();
         rng.sample_iter(&d).take(n).map(X::from).collect()
     }
 }
@@ -335,8 +335,8 @@ mod tests {
 
     #[test]
     fn cdf_inv_cdf_ident() {
-        let mut rng = rand::thread_rng();
-        let ru = rand::distributions::Uniform::new_inclusive(0_u32, 100_u32);
+        let mut rng = rand::rng();
+        let ru = rand_distr::Uniform::new_inclusive(0_u32, 100_u32).unwrap();
         let u = DiscreteUniform::new(0_u32, 100_u32).unwrap();
         for _ in 0..100 {
             let x: u32 = rng.sample(ru);
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let u = DiscreteUniform::new(0_u32, 100_u32).unwrap();
         let cdf = |x: u64| u.cdf(&x);
 

--- a/src/dist/empirical.rs
+++ b/src/dist/empirical.rs
@@ -171,7 +171,7 @@ impl HasDensity<f64> for Empirical {
 impl Sampleable<f64> for Empirical {
     fn draw<R: Rng>(&self, rng: &mut R) -> f64 {
         let n = self.xs.len();
-        let ix: usize = rng.gen_range(0..n);
+        let ix: usize = rng.random_range(0..n);
         self.xs[ix]
     }
 }
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn draw_smoke() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         // create a distribution with only a few bins so that draw hits all the
         // bins.
         let xs = vec![0.0, 1.0, 2.0];

--- a/src/dist/exponential.rs
+++ b/src/dist/exponential.rs
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let expon = Exponential::new(1.5).unwrap();
         let cdf = |x: f64| expon.cdf(&x);
 

--- a/src/dist/gamma.rs
+++ b/src/dist/gamma.rs
@@ -506,7 +506,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let gam = Gamma::new(1.2, 3.4).unwrap();
         let cdf = |x: f64| gam.cdf(&x);
 

--- a/src/dist/gamma/poisson_prior.rs
+++ b/src/dist/gamma/poisson_prior.rs
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn cannot_draw_zero_rate() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let dist = Gamma::new(1.0, 1e-10).unwrap();
         let stream =
             <Gamma as Sampleable<Poisson>>::sample_stream(&dist, &mut rng);

--- a/src/dist/gaussian.rs
+++ b/src/dist/gaussian.rs
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn draws_should_be_finite() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let gauss = Gaussian::standard();
         for _ in 0..100 {
             let x: f64 = gauss.draw(&mut rng);
@@ -500,7 +500,7 @@ mod tests {
 
     #[test]
     fn sample_length() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let gauss = Gaussian::standard();
         let xs: Vec<f64> = gauss.sample(10, &mut rng);
         assert_eq!(xs.len(), 10);
@@ -596,7 +596,7 @@ mod tests {
 
     #[test]
     fn quantile_agree_with_cdf() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let gauss = Gaussian::standard();
         let xs: Vec<f64> = gauss.sample(100, &mut rng);
 
@@ -614,7 +614,7 @@ mod tests {
         };
         let ig = Gaussian::new(-2.3, 0.5).unwrap();
         let pdf = |x: f64| ig.f(&x);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         for _ in 0..100 {
             let x: f64 = ig.draw(&mut rng);
             let res = gauss_kronrod_quadrature(

--- a/src/dist/geometric.rs
+++ b/src/dist/geometric.rs
@@ -182,7 +182,7 @@ impl Geometric {
         X: Unsigned + Integer + Saturating,
         R: Rng,
     {
-        let u: f64 = rng.gen();
+        let u: f64 = rng.random();
         let q = 1.0 - p;
 
         let mut t: X = X::zero();
@@ -404,7 +404,7 @@ mod tests {
     }
 
     fn test_draw_generic(p: f64) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let geom = Geometric::new(p).unwrap();
 
         // How many bins do we need?

--- a/src/dist/gev.rs
+++ b/src/dist/gev.rs
@@ -656,7 +656,7 @@ mod tests {
 
     #[test]
     fn draw_0() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let gev = Gev::new(0.0, 1.0, 0.0).unwrap();
         let cdf = |x: f64| gev.cdf(&x);
 
@@ -675,7 +675,7 @@ mod tests {
 
     #[test]
     fn draw_one_half() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let gev = Gev::new(0.0, 1.0, 0.5).unwrap();
         let cdf = |x: f64| gev.cdf(&x);
 
@@ -694,7 +694,7 @@ mod tests {
 
     #[test]
     fn draw_negative_one_half() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let gev = Gev::new(0.0, 1.0, -0.5).unwrap();
         let cdf = |x: f64| gev.cdf(&x);
 

--- a/src/dist/inv_chi_squared.rs
+++ b/src/dist/inv_chi_squared.rs
@@ -364,7 +364,7 @@ mod test {
 
     #[test]
     fn pdf_agrees_with_inv_gamma_special_case() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let v_prior = Gamma::new_unchecked(2.0, 1.0);
 
         for v in v_prior.sample_stream(&mut rng).take(1000) {
@@ -386,7 +386,7 @@ mod test {
 
     #[test]
     fn cdf_agrees_with_inv_gamma_special_case() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let v_prior = Gamma::new_unchecked(2.0, 1.0);
 
         for v in v_prior.sample_stream(&mut rng).take(1000) {
@@ -401,7 +401,7 @@ mod test {
 
     #[test]
     fn draw_agrees_with_cdf() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let ix2 = InvChiSquared::new(1.2).unwrap();
         let cdf = |x: f64| ix2.cdf(&x);
 

--- a/src/dist/invgamma.rs
+++ b/src/dist/invgamma.rs
@@ -464,7 +464,7 @@ mod tests {
         };
         let ig = InvGamma::new(2.3, 3.1).unwrap();
         let pdf = |x: f64| ig.f(&x);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         for _ in 0..100 {
             let x: f64 = ig.draw(&mut rng);
             let res = gauss_kronrod_quadrature(
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn sample_return_correct_number_of_draws() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let ig = InvGamma::new(3.0, 2.0).unwrap();
         let xs: Vec<f64> = ig.sample(103, &mut rng);
         assert_eq!(xs.len(), 103);
@@ -523,7 +523,7 @@ mod tests {
 
     #[test]
     fn draw_always_returns_results_in_support() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let ig = InvGamma::new(3.0, 2.0).unwrap();
         for _ in 0..100 {
             let x: f64 = ig.draw(&mut rng);
@@ -571,7 +571,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let ig = InvGamma::new(1.2, 3.4).unwrap();
         let cdf = |x: f64| ig.cdf(&x);
 

--- a/src/dist/invgaussian.rs
+++ b/src/dist/invgaussian.rs
@@ -279,7 +279,7 @@ macro_rules! impl_traits {
                     ),
                     mu,
                 );
-                let z: f64 = rng.gen();
+                let z: f64 = rng.random();
 
                 if z <= mu / (mu + x) {
                     x as $kind
@@ -405,7 +405,7 @@ mod tests {
 
     #[test]
     fn mode_is_highest_point() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mu_prior = crate::dist::InvGamma::new_unchecked(2.0, 2.0);
         let lambda_prior = crate::dist::InvGamma::new_unchecked(2.0, 2.0);
         for _ in 0..100 {
@@ -430,7 +430,7 @@ mod tests {
         let ig = InvGaussian::new(1.1, 2.5).unwrap();
         // use pdf to hit `supports(x)` first
         let pdf = |x: f64| ig.pdf(&x);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         for _ in 0..100 {
             let x: f64 = ig.draw(&mut rng);
             let res = gauss_kronrod_quadrature(
@@ -445,7 +445,7 @@ mod tests {
 
     #[test]
     fn draw_vs_kl() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let ig = InvGaussian::new(1.2, 3.4).unwrap();
         let cdf = |x: f64| ig.cdf(&x);
 

--- a/src/dist/ks.rs
+++ b/src/dist/ks.rs
@@ -290,7 +290,7 @@ macro_rules! impl_traits {
 
         impl Sampleable<$kind> for KsTwoAsymptotic {
             fn draw<R: Rng>(&self, rng: &mut R) -> $kind {
-                let p: f64 = rng.gen();
+                let p: f64 = rng.random();
                 self.invcdf(p)
             }
         }

--- a/src/dist/kumaraswamy.rs
+++ b/src/dist/kumaraswamy.rs
@@ -367,7 +367,7 @@ macro_rules! impl_kumaraswamy {
 
         impl Sampleable<$kind> for Kumaraswamy {
             fn draw<R: Rng>(&self, rng: &mut R) -> $kind {
-                let p: f64 = rng.gen();
+                let p: f64 = rng.random();
                 invcdf(p, self.a, self.b) as $kind
             }
         }
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     fn draw_should_return_values_within_0_to_1() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let kuma = Kumaraswamy::default();
         for _ in 0..100 {
             let x = kuma.draw(&mut rng);
@@ -487,7 +487,7 @@ mod tests {
 
     #[test]
     fn sample_returns_the_correct_number_draws() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let kuma = Kumaraswamy::default();
         let xs: Vec<f64> = kuma.sample(103, &mut rng);
         assert_eq!(xs.len(), 103);
@@ -496,7 +496,7 @@ mod tests {
     #[test]
     fn draws_from_correct_distribution() {
         let lognormal = LogNormal::new(0.0, 0.25).unwrap();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // test is flaky, try a few times
         let passes = (0..N_TRIES).fold(0, |acc, _| {
@@ -548,7 +548,7 @@ mod tests {
 
     #[test]
     fn equivalent_mean_to_beta_when_a_or_b_is_1() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // K(a, 1) = B(a, 1) and K(1, b) = B(1, b)
         fn equiv(p: f64) {
@@ -577,7 +577,7 @@ mod tests {
 
     #[test]
     fn equivalent_mode_to_beta_when_a_or_b_is_1() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // K(a, 1) = B(a, 1) and K(1, b) = B(1, b)
         fn equiv(p: f64) {

--- a/src/dist/laplace.rs
+++ b/src/dist/laplace.rs
@@ -425,7 +425,7 @@ mod tests {
     fn draw_test() {
         // Since we've had to implement the laplace draw ourselves, we have to
         // make sure the thing works, so we use the Kolmogorov-Smirnov test.
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let laplace = Laplace::new(1.2, 3.4).unwrap();
         let cdf = |x: f64| laplace.cdf(&x);
 

--- a/src/dist/lognormal.rs
+++ b/src/dist/lognormal.rs
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn draws_should_be_finite() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let lognorm = LogNormal::standard();
         for _ in 0..100 {
             let x: f64 = lognorm.draw(&mut rng);
@@ -416,7 +416,7 @@ mod tests {
 
     #[test]
     fn sample_length() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let lognorm = LogNormal::standard();
         let xs: Vec<f64> = lognorm.sample(10, &mut rng);
         assert_eq!(xs.len(), 10);

--- a/src/dist/mixture.rs
+++ b/src/dist/mixture.rs
@@ -1045,7 +1045,7 @@ mod tests {
 
     #[test]
     fn mean_of_sample_should_be_weighted_dist_means_uniform() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mm = Mixture::new(
             vec![0.5, 0.5],
             vec![
@@ -1073,7 +1073,7 @@ mod tests {
 
     #[test]
     fn mean_of_sample_should_be_weighted_dist_means_nonuniform() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mm = Mixture::new(
             vec![0.9, 0.1],
             vec![
@@ -1377,7 +1377,7 @@ mod tests {
         fn gauss_mixture_quad_bounds_have_zero_pdf() {
             use crate::dist::{InvGamma, Poisson};
 
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let pois = Poisson::new(7.0).unwrap();
 
             let mu_prior = Gaussian::new(0.0, 5.0).unwrap();

--- a/src/dist/neg_binom.rs
+++ b/src/dist/neg_binom.rs
@@ -597,7 +597,7 @@ mod tests {
 
         let n_tries = 5;
         let x2_pval = 0.2;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let nbin = NegBinomial::new(3.0, 0.6).unwrap();
 
         // How many bins do we need?
@@ -629,7 +629,7 @@ mod tests {
 
         let n_tries = 5;
         let x2_pval = 0.2;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let nbin = NegBinomial::new(3.0, 0.6).unwrap();
 
         // How many bins do we need?

--- a/src/dist/normal_gamma/gaussian_prior.rs
+++ b/src/dist/normal_gamma/gaussian_prior.rs
@@ -103,7 +103,7 @@ mod tests {
     fn geweke() {
         use crate::test::GewekeTester;
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let pr = NormalGamma::new(0.1, 1.2, 0.5, 1.8).unwrap();
         let n_passes = (0..5)
             .map(|_| {
@@ -194,7 +194,7 @@ mod tests {
         let ln_m = ng.ln_m(&DataOrSuffStat::<f64, Gaussian>::from(&xs));
 
         let mc_est = {
-            ng.sample_stream(&mut rand::thread_rng())
+            ng.sample_stream(&mut rand::rng())
                 .take(n_samples)
                 .map(|gauss: Gaussian| {
                     xs.iter().map(|x| gauss.ln_f(x)).sum::<f64>()
@@ -219,7 +219,7 @@ mod tests {
         let post = ng.posterior(&DataOrSuffStat::<f64, Gaussian>::from(&xs));
 
         let mc_est = {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             // let pr_p = Gamma::new(1.6, 2.2).unwrap();
             // let pr_m = Gaussian::new(1.0, 2.0).unwrap();
             let ln_fs = (0..n_samples).map(|_| {

--- a/src/dist/normal_inv_chi_squared/gaussian_prior.rs
+++ b/src/dist/normal_inv_chi_squared/gaussian_prior.rs
@@ -115,7 +115,7 @@ mod test {
     fn geweke() {
         use crate::test::GewekeTester;
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let pr = NormalInvChiSquared::new(0.1, 1.2, 0.5, 1.8).unwrap();
         let n_passes = (0..5)
             .map(|_| {
@@ -233,7 +233,7 @@ mod test {
         let ln_m = nix.ln_m(&DataOrSuffStat::<f64, Gaussian>::from(&xs));
 
         let mc_est = {
-            nix.sample_stream(&mut rand::thread_rng())
+            nix.sample_stream(&mut rand::rng())
                 .take(n_samples)
                 .map(|gauss: Gaussian| gauss.ln_f(&x))
                 .logsumexp()
@@ -255,7 +255,7 @@ mod test {
         let ln_m = nix.ln_m(&DataOrSuffStat::<f64, Gaussian>::from(&xs));
 
         let mc_est = {
-            nix.sample_stream(&mut rand::thread_rng())
+            nix.sample_stream(&mut rand::rng())
                 .take(n_samples)
                 .map(|gauss: Gaussian| {
                     xs.iter().map(|x| gauss.ln_f(x)).sum::<f64>()
@@ -281,7 +281,7 @@ mod test {
         let ln_pp = nix.ln_pp(&y, &DataOrSuffStat::<f64, Gaussian>::from(&xs));
 
         let mc_est = {
-            post.sample_stream(&mut rand::thread_rng())
+            post.sample_stream(&mut rand::rng())
                 .take(n_samples)
                 .map(|gauss: Gaussian| gauss.ln_f(&y))
                 .logsumexp()
@@ -304,7 +304,7 @@ mod test {
             nix.ln_pp(&x, &DataOrSuffStat::<f64, Gaussian>::from(&vec![]));
 
         let mc_est = {
-            nix.sample_stream(&mut rand::thread_rng())
+            nix.sample_stream(&mut rand::rng())
                 .take(n_samples)
                 .map(|gauss: Gaussian| gauss.ln_f(&x))
                 .logsumexp()

--- a/src/dist/normal_inv_gamma/gaussian_prior.rs
+++ b/src/dist/normal_inv_gamma/gaussian_prior.rs
@@ -115,7 +115,7 @@ mod test {
     fn geweke() {
         use crate::test::GewekeTester;
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let pr = NormalInvGamma::new(0.1, 1.2, 0.5, 1.8).unwrap();
         let n_passes = (0..5)
             .map(|_| {
@@ -198,7 +198,7 @@ mod test {
     fn ln_f_vs_reference() {
         let (m, v, a, b) = (0.0, 1.2, 2.3, 3.4);
         let nig = NormalInvGamma::new(m, v, a, b).unwrap();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         for _ in 0..100 {
             let gauss = nig.draw(&mut rng);
             let ln_f = nig.ln_f(&gauss);
@@ -231,7 +231,7 @@ mod test {
         // let ln_m = alternate_ln_marginal(&xs, m, v, a, b);
 
         let mc_est = {
-            nig.sample_stream(&mut rand::thread_rng())
+            nig.sample_stream(&mut rand::rng())
                 .take(n_samples)
                 .map(|gauss: Gaussian| {
                     xs.iter().map(|x| gauss.ln_f(x)).sum::<f64>()
@@ -256,7 +256,7 @@ mod test {
         let ln_m = nig.ln_m(&DataOrSuffStat::<f64, Gaussian>::from(&xs));
 
         let mc_est = {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let pr_m = Gaussian::new(1.0, 8.0).unwrap();
             let pr_s = Gamma::new(2.0, 0.4).unwrap();
             let ln_fs = (0..n_samples).map(|_| {
@@ -287,7 +287,7 @@ mod test {
         // let ln_m = alternate_ln_marginal(&xs, m, v, a, b);
 
         let mc_est = {
-            post.sample_stream(&mut rand::thread_rng())
+            post.sample_stream(&mut rand::rng())
                 .take(n_samples)
                 .map(|gauss: Gaussian| gauss.ln_f(&y))
                 .logsumexp()

--- a/src/dist/pareto.rs
+++ b/src/dist/pareto.rs
@@ -609,7 +609,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let par = Pareto::new(1.2, 3.4).unwrap();
         let cdf = |x: f64| par.cdf(&x);
 

--- a/src/dist/poisson.rs
+++ b/src/dist/poisson.rs
@@ -463,7 +463,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let pois = Poisson::new(2.0).unwrap();
 
         // How many bins do we need?
@@ -491,7 +491,7 @@ mod tests {
     #[test]
     fn kl_divergence_vs_brute() {
         let prior = crate::dist::Gamma::new(1.0, 1.0).unwrap();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         for _ in 0..10 {
             let pois_x: Poisson = prior.draw(&mut rng);

--- a/src/dist/scaled_inv_chi_squared.rs
+++ b/src/dist/scaled_inv_chi_squared.rs
@@ -481,7 +481,7 @@ mod test {
 
     #[test]
     fn pdf_agrees_with_inv_gamma_special_case() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let v_prior = Gamma::new_unchecked(2.0, 1.0);
         let t2_prior = Gamma::new_unchecked(2.0, 1.0);
 
@@ -509,7 +509,7 @@ mod test {
 
     #[test]
     fn cdf_agrees_with_inv_gamma_special_case() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let v_prior = Gamma::new_unchecked(2.0, 1.0);
         let t2_prior = Gamma::new_unchecked(2.0, 1.0);
 
@@ -530,7 +530,7 @@ mod test {
 
     #[test]
     fn draw_agrees_with_cdf() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let ix2 = ScaledInvChiSquared::new(1.2, 3.4).unwrap();
         let cdf = |x: f64| ix2.cdf(&x);
 

--- a/src/dist/skellam.rs
+++ b/src/dist/skellam.rs
@@ -431,7 +431,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let pois = Skellam::new(3.0, 3.0).unwrap();
 
         // How many bins do we need?

--- a/src/dist/uniform.rs
+++ b/src/dist/uniform.rs
@@ -194,12 +194,12 @@ macro_rules! impl_traits {
 
         impl Sampleable<$kind> for Uniform {
             fn draw<R: Rng>(&self, rng: &mut R) -> $kind {
-                let u = rand_distr::Uniform::new(self.a, self.b);
+                let u = rand_distr::Uniform::new(self.a, self.b).unwrap();
                 rng.sample(u) as $kind
             }
 
             fn sample<R: Rng>(&self, n: usize, rng: &mut R) -> Vec<$kind> {
-                let u = rand_distr::Uniform::new(self.a, self.b);
+                let u = rand_distr::Uniform::new(self.a, self.b).unwrap();
                 (0..n).map(|_| rng.sample(u) as $kind).collect()
             }
         }
@@ -375,8 +375,8 @@ mod tests {
 
     #[test]
     fn cdf_inv_cdf_ident() {
-        let mut rng = rand::thread_rng();
-        let ru = rand::distributions::Uniform::new(1.2, 3.4);
+        let mut rng = rand::rng();
+        let ru = rand_distr::Uniform::new(1.2, 3.4).unwrap();
         let u = Uniform::new(1.2, 3.4).unwrap();
         for _ in 0..100 {
             let x: f64 = rng.sample(ru);
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let u = Uniform::new(1.2, 3.4).unwrap();
         let cdf = |x: f64| u.cdf(&x);
 

--- a/src/dist/unit_powerlaw.rs
+++ b/src/dist/unit_powerlaw.rs
@@ -222,12 +222,14 @@ macro_rules! impl_traits {
 
         impl Sampleable<$kind> for UnitPowerLaw {
             fn draw<R: Rng>(&self, rng: &mut R) -> $kind {
-                self.invcdf(rng.gen::<f64>())
+                self.invcdf(rng.random::<f64>())
             }
 
             fn sample<R: Rng>(&self, n: usize, rng: &mut R) -> Vec<$kind> {
                 let alpha_inv = self.alpha_inv() as $kind;
-                (0..n).map(|_| rng.gen::<$kind>().powf(alpha_inv)).collect()
+                (0..n)
+                    .map(|_| rng.random::<$kind>().powf(alpha_inv))
+                    .collect()
             }
         }
 
@@ -429,7 +431,7 @@ mod tests {
 
     #[test]
     fn draw_should_return_values_within_0_to_1() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let powlaw = UnitPowerLaw::new(2.0).unwrap();
         for _ in 0..100 {
             let x = powlaw.draw(&mut rng);
@@ -439,7 +441,7 @@ mod tests {
 
     #[test]
     fn sample_returns_the_correct_number_draws() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let powlaw = UnitPowerLaw::new(2.0).unwrap();
         let xs: Vec<f32> = powlaw.sample(103, &mut rng);
         assert_eq!(xs.len(), 103);
@@ -516,7 +518,7 @@ mod tests {
 
     #[test]
     fn draw_test_alpha_powlaw_gt_one() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let powlaw = UnitPowerLaw::new(1.2).unwrap();
         let cdf = |x: f64| powlaw.cdf(&x);
 
@@ -536,7 +538,7 @@ mod tests {
 
     #[test]
     fn draw_test_alpha_powlaw_lt_one() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let powlaw = UnitPowerLaw::new(0.2).unwrap();
         let cdf = |x: f64| powlaw.cdf(&x);
 
@@ -571,20 +573,20 @@ mod tests {
 
     #[test]
     fn set_alpha() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         for _ in 0..100 {
-            let a1 = rng.gen::<f64>();
+            let a1 = rng.random::<f64>();
             let mut powlaw1 = UnitPowerLaw::new(a1).unwrap();
 
             // Any value in the unit interval
-            let x: f64 = rng.gen();
+            let x: f64 = rng.random();
 
             // Evaluate the pdf to force computation of `ln_powlaw_ab`
             let _ = powlaw1.pdf(&x);
 
             // Next we'll `set_alpha` to a2, and compare with a fresh UnitPowerLaw
-            let a2 = rng.gen::<f64>();
+            let a2 = rng.random::<f64>();
 
             // Setting the new values
             powlaw1.set_alpha(a2).unwrap();

--- a/src/dist/vonmises.rs
+++ b/src/dist/vonmises.rs
@@ -255,7 +255,7 @@ macro_rules! impl_traits {
             //     von Mises distribution. Applied Statistics, 152-157.
             // https://www.researchgate.net/publication/246035131_Efficient_Simulation_of_the_von_Mises_Distribution
             fn draw<R: Rng>(&self, rng: &mut R) -> $kind {
-                let u = rand::distributions::Open01;
+                let u = rand_distr::Open01;
                 let tau = 1.0 + 4.0_f64.mul_add(self.k * self.k, 1.0).sqrt();
                 let rho = (tau * (2.0 * tau).sqrt()) / (2.0 * self.k);
                 let r = rho.mul_add(rho, 1.0) / (2.0 * rho);
@@ -488,7 +488,7 @@ mod tests {
 
     #[test]
     fn all_samples_should_be_supported() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         // kappa should be low so we get samples at the tails
         let vm = VonMises::new(1.5 * PI, 0.25).unwrap();
         let xs: Vec<f64> = vm.sample(1000, &mut rng);
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn vm_draw_test() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let vm = VonMises::new(1.0, 1.2).unwrap();
         let cdf = |x: f64| vm.cdf(&x);
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -88,7 +88,7 @@ where
     }
 
     /// Return the observations
-    fn obs(&self) -> DataOrSuffStat<X, Fx> {
+    fn obs(&'_ self) -> DataOrSuffStat<'_, X, Fx> {
         DataOrSuffStat::SuffStat(&self.suffstat)
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -18,7 +18,7 @@ macro_rules! test_basic_impls {
 
             #[test]
             fn should_impl_debug_clone_and_partialeq() {
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 // make the expression a thing. If we don't do this, calling $fx
                 // reconstructs the distribution which means we don't do caching
                 let fx = $fx;
@@ -44,7 +44,7 @@ macro_rules! test_basic_impls {
 
             #[test]
             fn should_impl_parameterized() {
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
 
                 let fx_1 = $fx;
                 let params = fx_1.emit_params();
@@ -379,7 +379,7 @@ macro_rules! test_conjugate_prior {
                 // If this doesn't work, one of two things could be wrong:
                 // 1. prior.ln_m is wrong
                 // 2. prior.ln_pp is wrong
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
 
                 let pr = $prior;
                 let fx: $Fx = pr.draw(&mut rng);
@@ -416,7 +416,7 @@ macro_rules! test_conjugate_prior {
                 // 2. fx.ln_f(x)
                 // 3. prior.ln_f(fx)
                 // 4. prior.ln_m(x)
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
 
                 let pr = $prior;
                 let fx: $Fx = pr.draw(&mut rng);
@@ -458,7 +458,7 @@ macro_rules! test_conjugate_prior {
                 // 2. fx.ln_f_stat is wrong
                 // 3. prior.m is wrong
                 let n_tries = 5;
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
 
                 let pr = $prior;
 

--- a/tests/mi.rs
+++ b/tests/mi.rs
@@ -9,7 +9,7 @@ fn bivariate_mixture_mi() {
     let n_samples = 100_000;
     let n_f = n_samples as f64;
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let mx = Mixture::uniform(vec![
         Gaussian::new_unchecked(-2.0, 1.0),
@@ -49,7 +49,7 @@ fn bivariate_mixture_mi() {
     let (mi_est, hxy_est) = {
         let (mi_sum, hxy_sum) =
             (0..n_samples).fold((0.0, 0.0), |(mi, hxy), _| {
-                let cpnt_ix = rng.gen_range(0..k);
+                let cpnt_ix = rng.random_range(0..k);
 
                 let x: f64 = mx.components()[cpnt_ix].draw(&mut rng);
                 let y: f64 = my.components()[cpnt_ix].draw(&mut rng);


### PR DESCRIPTION
This involved just fixing a bunch of deprecation warnings.

I've also bumped `argmin` which removes `rand` 0.8 / `rand_distr` 0.4 from the dependency graph (except for the unused `peroxide` dev dependency which can probably be removed now)