### PR TITLE
Fix InvGaussian skewness and Skellam kurtosis formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `InvGaussian::skewness` now returns `3 * sqrt(mu / lambda)` instead of
+  `2 * sqrt(mu / lambda)`.
+- `Skellam::kurtosis` now returns the excess (Fisher) kurtosis
+  `1 / (mu_1 + mu_2)` rather than the full kurtosis `3 + 1 / (mu_1 + mu_2)`,
+  matching the excess-kurtosis convention used by every other distribution.
+
 ## [0.20.1] - 2026-05-18
 
 ### Fixed

--- a/src/dist/invgaussian.rs
+++ b/src/dist/invgaussian.rs
@@ -370,7 +370,7 @@ impl Variance<f64> for InvGaussian {
 
 impl Skewness for InvGaussian {
     fn skewness(&self) -> Option<f64> {
-        Some(2.0 * (self.mu / self.lambda).sqrt())
+        Some(3.0 * (self.mu / self.lambda).sqrt())
     }
 }
 
@@ -416,6 +416,22 @@ mod tests {
         InvGaussian,
         InvGaussian::new(1.0, 2.3).unwrap()
     );
+
+    #[test]
+    fn skewness_and_kurtosis() {
+        // skewness = 3 * sqrt(mu / lambda), excess kurtosis = 15 * mu / lambda
+        let ig = InvGaussian::new(1.0, 1.0).unwrap();
+        assert::close(ig.skewness().unwrap(), 3.0, 1e-12);
+        assert::close(ig.kurtosis().unwrap(), 15.0, 1e-12);
+
+        let ig = InvGaussian::new(2.0, 1.5).unwrap();
+        assert::close(ig.skewness().unwrap(), 3.464_101_615_137_754_4, 1e-12);
+        assert::close(ig.kurtosis().unwrap(), 20.0, 1e-12);
+
+        let ig = InvGaussian::new(0.5, 4.0).unwrap();
+        assert::close(ig.skewness().unwrap(), 1.060_660_171_779_821_2, 1e-12);
+        assert::close(ig.kurtosis().unwrap(), 1.875, 1e-12);
+    }
 
     #[test]
     fn mode_is_highest_point() {

--- a/src/dist/skellam.rs
+++ b/src/dist/skellam.rs
@@ -324,7 +324,8 @@ impl Skewness for Skellam {
 
 impl Kurtosis for Skellam {
     fn kurtosis(&self) -> Option<f64> {
-        Some(3.0 + (self.mu_1 + self.mu_2).recip())
+        // Excess (Fisher) kurtosis, matching every other distribution.
+        Some((self.mu_1 + self.mu_2).recip())
     }
 }
 
@@ -434,8 +435,9 @@ mod tests {
 
     #[test]
     fn kurtosis() {
+        // Excess kurtosis of Skellam is 1 / (mu_1 + mu_2) = 1 / 9.8.
         let k = Skellam::new(5.3, 4.5).unwrap().kurtosis().unwrap();
-        assert::close(k, 3.102_040_816_326_530_5, TOL);
+        assert::close(k, 0.102_040_816_326_530_5, TOL);
     }
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -404,6 +404,7 @@ pub trait Skewness {
 }
 
 pub trait Kurtosis {
+    /// The excess (Fisher) kurtosis, or `None` if undefined
     fn kurtosis(&self) -> Option<f64>;
 }
 


### PR DESCRIPTION
Two closed-form moment methods return wrong values. Both are easy to confirm against `scipy.stats`.

**`InvGaussian::skewness`** returns `2 * sqrt(mu/lambda)`. The skewness of the inverse Gaussian (Wald) distribution is `3 * sqrt(mu/lambda)`, so the result is ~33% too small for every parameter. The excess kurtosis on the next line (`15*mu/lambda`) is already correct.

```
InvGaussian::new(1.0, 1.0).skewness()               // 2.0, should be 3.0
scipy.stats.invgauss(mu=1.0, scale=1.0).stats('s')  // 3.0
```

**`Skellam::kurtosis`** returns `3 + 1/(mu_1 + mu_2)`, i.e. the *full* kurtosis. Every other distribution in the crate returns *excess* kurtosis (Gaussian = 0, Uniform = -1.2, Poisson = 1/rate, StudentsT = 6/(v-4), ...), which also matches scipy's Fisher kurtosis, so Skellam should return `1/(mu_1 + mu_2)`. The existing `kurtosis` test had baked in the full value (`3.102...` for `Skellam(5.3, 4.5)`); I corrected it to the excess value `1/9.8`.

I ran the skewness and excess-kurtosis of the other 19 distributions against scipy over a parameter grid and they all agree — these two methods were the only divergences. Added the first skewness/kurtosis test for `InvGaussian`, and a short note on the `Kurtosis` trait documenting that it returns excess kurtosis.
